### PR TITLE
Implement SQLite-backed ingest and vector search CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module yashubustudio/csv-search
 go 1.24.5
 
 require (
-	github.com/sugarme/tokenizer v0.3.0
-	github.com/yalue/onnxruntime_go v1.21.0
+        github.com/sugarme/tokenizer v0.3.0
+        github.com/yalue/onnxruntime_go v1.21.0
+        modernc.org/sqlite v1.27.0
 )
 
 require (

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,0 +1,52 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Open opens or creates a SQLite database located at path using the modernc
+// pure-Go driver. The directory that contains the database file is created if
+// necessary.
+func Open(path string) (*sql.DB, error) {
+	if path == "" {
+		return nil, fmt.Errorf("database path must not be empty")
+	}
+	dir := filepath.Dir(path)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("create db dir: %w", err)
+		}
+	}
+
+	dsn := fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)", path)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetConnMaxLifetime(0)
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// Init prepares the database schema using the statements defined in schema.go.
+func Init(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+	return applySchema(ctx, db, schema)
+}

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+var schema = []string{
+	"PRAGMA journal_mode=WAL;",
+	`CREATE TABLE IF NOT EXISTS items (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                body TEXT,
+                tags TEXT,
+                category TEXT,
+                price REAL,
+                stock INTEGER,
+                created_at INTEGER,
+                updated_at INTEGER,
+                lat REAL,
+                lng REAL,
+                hash TEXT
+        );`,
+	`CREATE TABLE IF NOT EXISTS items_vec (
+                id TEXT PRIMARY KEY,
+                embedding BLOB NOT NULL
+        );`,
+	`CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
+                id UNINDEXED,
+                title,
+                body,
+                tags
+        );`,
+	`CREATE VIRTUAL TABLE IF NOT EXISTS items_rtree USING rtree(
+                item_rowid,
+                min_lat,
+                max_lat,
+                min_lng,
+                max_lng
+        );`,
+	`CREATE INDEX IF NOT EXISTS idx_items_category ON items(category);`,
+	`CREATE INDEX IF NOT EXISTS idx_items_price ON items(price);`,
+	`CREATE INDEX IF NOT EXISTS idx_items_stock ON items(stock);`,
+	`CREATE INDEX IF NOT EXISTS idx_items_created_at ON items(created_at);`,
+}
+
+func applySchema(ctx context.Context, db *sql.DB, statements []string) error {
+	for _, stmt := range statements {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("apply schema %q: %w", stmt, err)
+		}
+	}
+	return nil
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,0 +1,537 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/csv"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"yashubustudio/csv-search/emb"
+	"yashubustudio/csv-search/internal/vector"
+)
+
+// ColumnMapping describes how CSV columns map to internal fields. Leaving a
+// value empty disables the corresponding column. The ingest CLI sets sensible
+// defaults such as "id", "title", ... but callers may override them.
+type ColumnMapping struct {
+	ID        string
+	Title     string
+	Body      string
+	Tags      string
+	Category  string
+	Price     string
+	Stock     string
+	CreatedAt string
+	UpdatedAt string
+	Lat       string
+	Lng       string
+}
+
+// Options control the ingest process.
+type Options struct {
+	CSVPath   string
+	BatchSize int
+	Columns   ColumnMapping
+}
+
+type columnIndexes struct {
+	ID        int
+	Title     int
+	Body      int
+	Tags      int
+	Category  int
+	Price     int
+	Stock     int
+	CreatedAt int
+	UpdatedAt int
+	Lat       int
+	Lng       int
+}
+
+type item struct {
+	ID        string
+	Title     string
+	Body      string
+	Tags      string
+	Category  string
+	Price     *float64
+	Stock     *int64
+	CreatedAt *int64
+	UpdatedAt *int64
+	Lat       *float64
+	Lng       *float64
+}
+
+// Run reads the CSV file at opts.CSVPath, converts records into database rows
+// and stores them with embeddings generated via enc. The caller must provide an
+// initialized encoder (see emb.Encoder).
+func Run(ctx context.Context, db *sql.DB, enc *emb.Encoder, opts Options) error {
+	if opts.CSVPath == "" {
+		return errors.New("csv path is required")
+	}
+	if db == nil {
+		return errors.New("db is nil")
+	}
+	if enc == nil {
+		return errors.New("encoder is nil")
+	}
+
+	file, err := os.Open(opts.CSVPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
+
+	header, err := reader.Read()
+	if err != nil {
+		return fmt.Errorf("read header: %w", err)
+	}
+	idx, err := resolveColumns(header, opts.Columns)
+	if err != nil {
+		return err
+	}
+
+	batchSize := opts.BatchSize
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if tx != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	rowsProcessed := 0
+	line := 1 // header already read
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		line++
+		if err != nil {
+			return fmt.Errorf("read row %d: %w", line, err)
+		}
+
+		it, err := buildItem(record, idx)
+		if err != nil {
+			return fmt.Errorf("row %d: %w", line, err)
+		}
+		hash := hashItem(it)
+
+		skip, err := shouldSkip(ctx, tx, it.ID, hash)
+		if err != nil {
+			return fmt.Errorf("row %d: %w", line, err)
+		}
+		if skip {
+			continue
+		}
+
+		text := embeddingText(it)
+		var embedding []float32
+		if strings.TrimSpace(text) != "" {
+			embedding, err = enc.Encode(text)
+			if err != nil {
+				return fmt.Errorf("row %d encode: %w", line, err)
+			}
+		}
+
+		if err := upsertItem(ctx, tx, it, hash, embedding); err != nil {
+			return fmt.Errorf("row %d: %w", line, err)
+		}
+
+		rowsProcessed++
+		if rowsProcessed%batchSize == 0 {
+			if err := tx.Commit(); err != nil {
+				return err
+			}
+			tx = nil
+			tx, err = db.BeginTx(ctx, nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+		tx = nil
+	}
+	return nil
+}
+
+func resolveColumns(header []string, mapping ColumnMapping) (columnIndexes, error) {
+	lookup := make(map[string]int, len(header))
+	for i, h := range header {
+		key := strings.ToLower(strings.TrimSpace(h))
+		lookup[key] = i
+	}
+
+	result := columnIndexes{
+		Title:     -1,
+		Body:      -1,
+		Tags:      -1,
+		Category:  -1,
+		Price:     -1,
+		Stock:     -1,
+		CreatedAt: -1,
+		UpdatedAt: -1,
+		Lat:       -1,
+		Lng:       -1,
+	}
+
+	get := func(name string, required bool) (int, error) {
+		if name == "" {
+			return -1, nil
+		}
+		idx, ok := lookup[strings.ToLower(strings.TrimSpace(name))]
+		if !ok {
+			if required {
+				return -1, fmt.Errorf("column %q not found", name)
+			}
+			return -1, nil
+		}
+		return idx, nil
+	}
+
+	var err error
+	result.ID, err = get(mapping.ID, true)
+	if err != nil {
+		return result, err
+	}
+	if result.ID < 0 {
+		return result, errors.New("id column is required")
+	}
+
+	if result.Title, err = get(mapping.Title, false); err != nil {
+		return result, err
+	}
+	if result.Body, err = get(mapping.Body, false); err != nil {
+		return result, err
+	}
+	if result.Tags, err = get(mapping.Tags, false); err != nil {
+		return result, err
+	}
+	if result.Category, err = get(mapping.Category, false); err != nil {
+		return result, err
+	}
+	if result.Price, err = get(mapping.Price, false); err != nil {
+		return result, err
+	}
+	if result.Stock, err = get(mapping.Stock, false); err != nil {
+		return result, err
+	}
+	if result.CreatedAt, err = get(mapping.CreatedAt, false); err != nil {
+		return result, err
+	}
+	if result.UpdatedAt, err = get(mapping.UpdatedAt, false); err != nil {
+		return result, err
+	}
+	if result.Lat, err = get(mapping.Lat, false); err != nil {
+		return result, err
+	}
+	if result.Lng, err = get(mapping.Lng, false); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func buildItem(record []string, idx columnIndexes) (*item, error) {
+	if idx.ID >= len(record) || idx.ID < 0 {
+		return nil, errors.New("id column missing in record")
+	}
+	get := func(i int) string {
+		if i < 0 || i >= len(record) {
+			return ""
+		}
+		return strings.TrimSpace(record[i])
+	}
+
+	it := &item{
+		ID:       get(idx.ID),
+		Title:    get(idx.Title),
+		Body:     get(idx.Body),
+		Tags:     get(idx.Tags),
+		Category: get(idx.Category),
+	}
+	if it.ID == "" {
+		return nil, errors.New("id column is empty")
+	}
+
+	if idx.Price >= 0 {
+		val := get(idx.Price)
+		if parsed, err := parseFloat(val); err != nil {
+			return nil, fmt.Errorf("price: %w", err)
+		} else {
+			it.Price = parsed
+		}
+	}
+	if idx.Stock >= 0 {
+		val := get(idx.Stock)
+		if parsed, err := parseInt(val); err != nil {
+			return nil, fmt.Errorf("stock: %w", err)
+		} else {
+			it.Stock = parsed
+		}
+	}
+	if idx.CreatedAt >= 0 {
+		val := get(idx.CreatedAt)
+		if parsed, err := parseTime(val); err != nil {
+			return nil, fmt.Errorf("created_at: %w", err)
+		} else {
+			it.CreatedAt = parsed
+		}
+	}
+	if idx.UpdatedAt >= 0 {
+		val := get(idx.UpdatedAt)
+		if parsed, err := parseTime(val); err != nil {
+			return nil, fmt.Errorf("updated_at: %w", err)
+		} else {
+			it.UpdatedAt = parsed
+		}
+	}
+	if idx.Lat >= 0 {
+		val := get(idx.Lat)
+		if parsed, err := parseFloat(val); err != nil {
+			return nil, fmt.Errorf("lat: %w", err)
+		} else {
+			it.Lat = parsed
+		}
+	}
+	if idx.Lng >= 0 {
+		val := get(idx.Lng)
+		if parsed, err := parseFloat(val); err != nil {
+			return nil, fmt.Errorf("lng: %w", err)
+		} else {
+			it.Lng = parsed
+		}
+	}
+	return it, nil
+}
+
+func parseFloat(val string) (*float64, error) {
+	if val == "" {
+		return nil, nil
+	}
+	f, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+func parseInt(val string) (*int64, error) {
+	if val == "" {
+		return nil, nil
+	}
+	i, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &i, nil
+}
+
+func parseTime(val string) (*int64, error) {
+	if val == "" {
+		return nil, nil
+	}
+	if i, err := strconv.ParseInt(val, 10, 64); err == nil {
+		return &i, nil
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, val); err == nil {
+			unix := t.Unix()
+			return &unix, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot parse time value %q", val)
+}
+
+func hashItem(it *item) string {
+	parts := []string{
+		it.ID,
+		it.Title,
+		it.Body,
+		it.Tags,
+		it.Category,
+		formatFloat(it.Price),
+		formatInt(it.Stock),
+		formatInt(it.CreatedAt),
+		formatInt(it.UpdatedAt),
+		formatFloat(it.Lat),
+		formatFloat(it.Lng),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(sum[:])
+}
+
+func formatFloat(v *float64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatFloat(*v, 'f', -1, 64)
+}
+
+func formatInt(v *int64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatInt(*v, 10)
+}
+
+func shouldSkip(ctx context.Context, tx *sql.Tx, id, hash string) (bool, error) {
+	var existing sql.NullString
+	err := tx.QueryRowContext(ctx, `SELECT hash FROM items WHERE id = ?`, id).Scan(&existing)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if existing.Valid && existing.String == hash {
+		return true, nil
+	}
+	return false, nil
+}
+
+func embeddingText(it *item) string {
+	var parts []string
+	for _, v := range []string{it.Title, it.Body, it.Tags, it.Category} {
+		if strings.TrimSpace(v) != "" {
+			parts = append(parts, v)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func upsertItem(ctx context.Context, tx *sql.Tx, it *item, hash string, embedding []float32) error {
+	_, err := tx.ExecContext(ctx, `
+                INSERT INTO items(
+                        id, title, body, tags, category,
+                        price, stock, created_at, updated_at, lat, lng, hash
+                ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                        title=excluded.title,
+                        body=excluded.body,
+                        tags=excluded.tags,
+                        category=excluded.category,
+                        price=excluded.price,
+                        stock=excluded.stock,
+                        created_at=excluded.created_at,
+                        updated_at=excluded.updated_at,
+                        lat=excluded.lat,
+                        lng=excluded.lng,
+                        hash=excluded.hash;
+        `,
+		it.ID,
+		nullString(it.Title),
+		nullString(it.Body),
+		nullString(it.Tags),
+		nullString(it.Category),
+		nullFloat(it.Price),
+		nullInt(it.Stock),
+		nullInt(it.CreatedAt),
+		nullInt(it.UpdatedAt),
+		nullFloat(it.Lat),
+		nullFloat(it.Lng),
+		hash,
+	)
+	if err != nil {
+		return err
+	}
+
+	var rowid int64
+	if err := tx.QueryRowContext(ctx, `SELECT rowid FROM items WHERE id = ?`, it.ID).Scan(&rowid); err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM items_fts WHERE rowid = ?`, rowid); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO items_fts(rowid, id, title, body, tags) VALUES(?, ?, ?, ?, ?)`,
+		rowid,
+		it.ID,
+		nullString(it.Title),
+		nullString(it.Body),
+		nullString(it.Tags),
+	); err != nil {
+		return err
+	}
+
+	if it.Lat != nil && it.Lng != nil {
+		if _, err := tx.ExecContext(ctx, `INSERT OR REPLACE INTO items_rtree VALUES(?, ?, ?, ?, ?)`,
+			rowid,
+			*it.Lat,
+			*it.Lat,
+			*it.Lng,
+			*it.Lng,
+		); err != nil {
+			return err
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM items_rtree WHERE item_rowid = ?`, rowid); err != nil {
+			return err
+		}
+	}
+
+	if len(embedding) > 0 {
+		blob := vector.Serialize(embedding)
+		if _, err := tx.ExecContext(ctx, `
+                        INSERT INTO items_vec(id, embedding) VALUES(?, ?)
+                        ON CONFLICT(id) DO UPDATE SET embedding=excluded.embedding;
+                `, it.ID, blob); err != nil {
+			return err
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM items_vec WHERE id = ?`, it.ID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func nullString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func nullFloat(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func nullInt(v *int64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}

--- a/internal/search/vector.go
+++ b/internal/search/vector.go
@@ -1,0 +1,130 @@
+package search
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+
+	"yashubustudio/csv-search/emb"
+	"yashubustudio/csv-search/internal/vector"
+)
+
+// Result represents a row returned from a vector similarity search.
+type Result struct {
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Body      string   `json:"body"`
+	Tags      string   `json:"tags"`
+	Category  string   `json:"category"`
+	Price     *float64 `json:"price,omitempty"`
+	Stock     *int64   `json:"stock,omitempty"`
+	CreatedAt *int64   `json:"created_at,omitempty"`
+	UpdatedAt *int64   `json:"updated_at,omitempty"`
+	Lat       *float64 `json:"lat,omitempty"`
+	Lng       *float64 `json:"lng,omitempty"`
+	Score     float64  `json:"score"`
+}
+
+// VectorSearch encodes the query with enc and ranks items stored in the
+// database by cosine similarity. The topK parameter controls how many results
+// are returned (defaults to 10 when non-positive).
+func VectorSearch(ctx context.Context, db *sql.DB, enc *emb.Encoder, query string, topK int) ([]Result, error) {
+	if enc == nil {
+		return nil, fmt.Errorf("encoder is nil")
+	}
+	if db == nil {
+		return nil, fmt.Errorf("db is nil")
+	}
+	if query == "" {
+		return nil, fmt.Errorf("query must not be empty")
+	}
+	if topK <= 0 {
+		topK = 10
+	}
+
+	qvec, err := enc.Encode(query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.QueryContext(ctx, `
+                SELECT id, title, body, tags, category,
+                       price, stock, created_at, updated_at, lat, lng, embedding
+                FROM items
+                INNER JOIN items_vec USING(id);
+        `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var results []Result
+	for rows.Next() {
+		var (
+			r       Result
+			price   sql.NullFloat64
+			stock   sql.NullInt64
+			created sql.NullInt64
+			updated sql.NullInt64
+			lat     sql.NullFloat64
+			lng     sql.NullFloat64
+			blob    []byte
+		)
+		if err := rows.Scan(
+			&r.ID, &r.Title, &r.Body, &r.Tags, &r.Category,
+			&price, &stock, &created, &updated, &lat, &lng, &blob,
+		); err != nil {
+			return nil, err
+		}
+
+		vec, err := vector.Deserialize(blob)
+		if err != nil {
+			return nil, err
+		}
+		score := vector.Cosine(qvec, vec)
+		r.Score = score
+
+		if price.Valid {
+			v := price.Float64
+			r.Price = &v
+		}
+		if stock.Valid {
+			v := stock.Int64
+			r.Stock = &v
+		}
+		if created.Valid {
+			v := created.Int64
+			r.CreatedAt = &v
+		}
+		if updated.Valid {
+			v := updated.Int64
+			r.UpdatedAt = &v
+		}
+		if lat.Valid {
+			v := lat.Float64
+			r.Lat = &v
+		}
+		if lng.Valid {
+			v := lng.Float64
+			r.Lng = &v
+		}
+
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score == results[j].Score {
+			return results[i].ID < results[j].ID
+		}
+		return results[i].Score > results[j].Score
+	})
+
+	if len(results) > topK {
+		results = results[:topK]
+	}
+	return results, nil
+}

--- a/internal/vector/similarity.go
+++ b/internal/vector/similarity.go
@@ -1,0 +1,22 @@
+package vector
+
+import "math"
+
+// Cosine returns the cosine similarity between two vectors. If either vector is
+// zero or the lengths do not match the function returns 0.
+func Cosine(a, b []float32) float64 {
+	if len(a) == 0 || len(b) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		fa, fb := float64(a[i]), float64(b[i])
+		dot += fa * fb
+		na += fa * fa
+		nb += fb * fb
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/internal/vector/vector.go
+++ b/internal/vector/vector.go
@@ -1,0 +1,32 @@
+package vector
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// Serialize converts a float32 slice into a little-endian byte slice suitable
+// for storage inside SQLite BLOB columns.
+func Serialize(vec []float32) []byte {
+	out := make([]byte, 4*len(vec))
+	for i, v := range vec {
+		binary.LittleEndian.PutUint32(out[i*4:], math.Float32bits(v))
+	}
+	return out
+}
+
+// Deserialize converts a byte slice produced by Serialize back to a float32
+// slice.
+func Deserialize(data []byte) ([]float32, error) {
+	if len(data)%4 != 0 {
+		return nil, fmt.Errorf("invalid vector blob length %d", len(data))
+	}
+	n := len(data) / 4
+	out := make([]float32, n)
+	for i := 0; i < n; i++ {
+		bits := binary.LittleEndian.Uint32(data[i*4:])
+		out[i] = math.Float32frombits(bits)
+	}
+	return out, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"yashubustudio/csv-search/emb"
+	"yashubustudio/csv-search/internal/database"
+	"yashubustudio/csv-search/internal/ingest"
+	"yashubustudio/csv-search/internal/search"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+	ctx := context.Background()
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	var err error
+	switch cmd {
+	case "init":
+		err = runInit(ctx, args)
+	case "ingest":
+		err = runIngest(ctx, args)
+	case "search":
+		err = runSearch(ctx, args)
+	case "help", "-h", "--help":
+		usage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n", cmd)
+		usage()
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runInit(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("init", flag.ExitOnError)
+	dbPath := fs.String("db", "data/app.db", "path to SQLite database")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	db, err := database.Open(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	if err := database.Init(ctx, db); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "database initialized at %s\n", *dbPath)
+	return nil
+}
+
+func runIngest(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("ingest", flag.ExitOnError)
+	dbPath := fs.String("db", "data/app.db", "path to SQLite database")
+	csvPath := fs.String("csv", "", "path to source CSV file")
+	batchSize := fs.Int("batch", 1000, "rows per transaction batch")
+	ortLib := fs.String("ort-lib", "", "path to ONNX Runtime shared library")
+	modelPath := fs.String("model", "", "path to encoder ONNX model")
+	tokenizerPath := fs.String("tokenizer", "", "path to tokenizer.json")
+	maxSeqLen := fs.Int("max-seq-len", 512, "maximum sequence length for the encoder")
+
+	idCol := fs.String("id-col", "id", "CSV column containing the primary identifier")
+	titleCol := fs.String("title-col", "title", "CSV column for the title (empty to disable)")
+	bodyCol := fs.String("body-col", "body", "CSV column for the body (empty to disable)")
+	tagsCol := fs.String("tags-col", "tags", "CSV column for tags (empty to disable)")
+	categoryCol := fs.String("category-col", "category", "CSV column for category (empty to disable)")
+	priceCol := fs.String("price-col", "price", "CSV column for price (empty to disable)")
+	stockCol := fs.String("stock-col", "stock", "CSV column for stock (empty to disable)")
+	createdCol := fs.String("created-at-col", "created_at", "CSV column for created_at (empty to disable)")
+	updatedCol := fs.String("updated-at-col", "updated_at", "CSV column for updated_at (empty to disable)")
+	latCol := fs.String("lat-col", "lat", "CSV column for latitude (empty to disable)")
+	lngCol := fs.String("lng-col", "lng", "CSV column for longitude (empty to disable)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *csvPath == "" {
+		return fmt.Errorf("csv path is required")
+	}
+	if *ortLib == "" {
+		return fmt.Errorf("ort-lib is required")
+	}
+	if *modelPath == "" {
+		return fmt.Errorf("model is required")
+	}
+	if *tokenizerPath == "" {
+		return fmt.Errorf("tokenizer is required")
+	}
+
+	db, err := database.Open(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if err := database.Init(ctx, db); err != nil {
+		return err
+	}
+
+	enc := &emb.Encoder{}
+	cfg := emb.Config{
+		OrtDLL:        *ortLib,
+		ModelPath:     *modelPath,
+		TokenizerPath: *tokenizerPath,
+		MaxSeqLen:     *maxSeqLen,
+	}
+	if err := enc.Init(cfg); err != nil {
+		return err
+	}
+	defer enc.Close()
+
+	options := ingest.Options{
+		CSVPath:   *csvPath,
+		BatchSize: *batchSize,
+		Columns: ingest.ColumnMapping{
+			ID:        *idCol,
+			Title:     *titleCol,
+			Body:      *bodyCol,
+			Tags:      *tagsCol,
+			Category:  *categoryCol,
+			Price:     *priceCol,
+			Stock:     *stockCol,
+			CreatedAt: *createdCol,
+			UpdatedAt: *updatedCol,
+			Lat:       *latCol,
+			Lng:       *lngCol,
+		},
+	}
+
+	if err := ingest.Run(ctx, db, enc, options); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "ingested data from %s\n", *csvPath)
+	return nil
+}
+
+func runSearch(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("search", flag.ExitOnError)
+	dbPath := fs.String("db", "data/app.db", "path to SQLite database")
+	query := fs.String("query", "", "text query for semantic vector search")
+	topK := fs.Int("topk", 10, "number of results to return")
+	ortLib := fs.String("ort-lib", "", "path to ONNX Runtime shared library")
+	modelPath := fs.String("model", "", "path to encoder ONNX model")
+	tokenizerPath := fs.String("tokenizer", "", "path to tokenizer.json")
+	maxSeqLen := fs.Int("max-seq-len", 512, "maximum sequence length for the encoder")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *query == "" {
+		return fmt.Errorf("query is required")
+	}
+	if *ortLib == "" {
+		return fmt.Errorf("ort-lib is required")
+	}
+	if *modelPath == "" {
+		return fmt.Errorf("model is required")
+	}
+	if *tokenizerPath == "" {
+		return fmt.Errorf("tokenizer is required")
+	}
+
+	db, err := database.Open(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	enc := &emb.Encoder{}
+	cfg := emb.Config{
+		OrtDLL:        *ortLib,
+		ModelPath:     *modelPath,
+		TokenizerPath: *tokenizerPath,
+		MaxSeqLen:     *maxSeqLen,
+	}
+	if err := enc.Init(cfg); err != nil {
+		return err
+	}
+	defer enc.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	results, err := search.VectorSearch(ctx, db, enc, *query, *topK)
+	if err != nil {
+		return err
+	}
+	encJSON := json.NewEncoder(os.Stdout)
+	encJSON.SetIndent("", "  ")
+	return encJSON.Encode(results)
+}
+
+func usage() {
+	exe := filepath.Base(os.Args[0])
+	fmt.Fprintf(os.Stderr, `Usage: %s <command> [options]
+
+Commands:
+  init      Initialize the SQLite database schema
+  ingest    Ingest CSV data and generate embeddings
+  search    Perform a semantic vector search
+
+Use "%s <command> -h" to see command-specific options.
+`, exe, exe)
+}

--- a/onniruntimetest.go
+++ b/onniruntimetest.go
@@ -1,40 +1,45 @@
 package main
 
+/*
+// legacy main for manual encoder testing. Retained but disabled so the primary
+// application can define its own main in main.go.
 import (
-	"fmt"
-	"log"
-	"yashubustudio/csv-search/emb"
+        "fmt"
+        "log"
+
+        "yashubustudio/csv-search/emb"
 )
 
 func main() {
-	enc := &emb.Encoder{}
-	cfg := emb.Config{
-		OrtDLL:        `D:\Ollama\projects\csv-search\onnixruntime-win\lib\onnxruntime.dll`,
-		ModelPath:     `D:\Ollama\projects\csv-search\models\bge-m3\model.onnx`,
-		TokenizerPath: `D:\Ollama\projects\csv-search\models\bge-m3\tokenizer.json`,
-		MaxSeqLen:     512,
-	}
-	if err := enc.Init(cfg); err != nil {
-		log.Fatal(err)
-	}
-	defer enc.Close()
+        enc := &emb.Encoder{}
+        cfg := emb.Config{
+                OrtDLL:        `D:\\Ollama\\projects\\csv-search\\onnixruntime-win\\lib\\onnxruntime.dll`,
+                ModelPath:     `D:\\Ollama\\projects\\csv-search\\models\\bge-m3\\model.onnx`,
+                TokenizerPath: `D:\\Ollama\\projects\\csv-search\\models\\bge-m3\\tokenizer.json`,
+                MaxSeqLen:     512,
+        }
+        if err := enc.Init(cfg); err != nil {
+                log.Fatal(err)
+        }
+        defer enc.Close()
 
-	// 動作確認：2文の類似度
-	a := "渋谷で静かなWi-Fiカフェを探しています。"
-	b := "ノートPC作業に向いた落ち着いた喫茶店を知りたい。"
+        // 動作確認：2文の類似度
+        a := "渋谷で静かなWi-Fiカフェを探しています。"
+        b := "ノートPC作業に向いた落ち着いた喫茶店を知りたい。"
 
-	va, err := enc.Encode(a)
-	if err != nil {
-		log.Fatal(err)
-	}
-	vb, err := enc.Encode(b)
-	if err != nil {
-		log.Fatal(err)
-	}
+        va, err := enc.Encode(a)
+        if err != nil {
+                log.Fatal(err)
+        }
+        vb, err := enc.Encode(b)
+        if err != nil {
+                log.Fatal(err)
+        }
 
-	fmt.Printf("dim=%d\n", len(va))
-	fmt.Printf("cosine(a,b)=%.3f\n", cosine(va, vb))
+        fmt.Printf("dim=%d\n", len(va))
+        fmt.Printf("cosine(a,b)=%.3f\n", cosine(va, vb))
 }
+*/
 
 func cosine(a, b []float32) float64 {
 	var dot, na, nb float64


### PR DESCRIPTION
## Summary
- add a top-level CLI with init/ingest/search commands that drive the ONNX-based encoder
- implement SQLite schema management plus CSV ingestion with hashing, embeddings, FTS and R-tree maintenance
- add vector serialization/similarity helpers and keep the legacy ONNX test main commented for reference

## Testing
- go build ./... *(fails: module downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf8f5e6e08323b2af55cf3b73d6f5