### PR TITLE
Enable configurable datasets and flexible column mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 SemanticGeoSearchDBは、CSVファイルを取り込むだけでローカルのSQLiteデータベースへ正規化・差分同期し、テキストと位置情報を活用した高度な検索を単体パッケージで提供することを目指すプロジェクトです。【F:basePlan.md†L3-L24】 ネットワーク接続やクラウドサービスに依存せず、エンドユーザーが即座に検索環境を構築できることを目的としています。【F:basePlan.md†L12-L24】
 
 ## コンセプトとシステム構成
-CSVインポート → 差分検出・正規化 → ONNXによる埋め込み生成 → SQLite（items/items_vec/items_fts/items_rtree）への格納 → CLI/将来のAPIやUIからの検索という流れで動作します。【F:basePlan.md†L32-L52】【F:basePlan.md†L71-L111】 コア技術としてGo言語、SQLite（WAL/R\*Tree/FTS5）、ONNX Runtimeを採用し、クロスプラットフォームな単一バイナリ配布を想定しています。【F:basePlan.md†L56-L68】
+CSVインポート → 差分検出・正規化 → ONNXによる埋め込み生成 → SQLite（records/records_vec/records_fts/records_rtree）への格納 → CLI/将来のAPIやUIからの検索という流れで動作します。【F:basePlan.md†L32-L52】【F:basePlan.md†L71-L111】 コア技術としてGo言語、SQLite（WAL/R\*Tree/FTS5）、ONNX Runtimeを採用し、クロスプラットフォームな単一バイナリ配布を想定しています。【F:basePlan.md†L56-L68】
 
 ## 実装済みの主な機能
 - **CLIコマンド**: `init`でスキーマ初期化、`ingest`でCSV取り込みと埋め込み生成、`search`でベクトル類似検索が実行できます。【F:main.go†L18-L224】
-- **SQLiteスキーマ**: `items`（メタデータ＋差分検出ハッシュ）、`items_vec`（埋め込みBLOB）、`items_fts`（全文検索）、`items_rtree`（位置情報）など、検索機能に必要な構造を用意しています。【F:internal/database/schema.go†L10-L45】
-- **CSV取り込みパイプライン**: 列マッピングを柔軟に指定し、レコードごとのハッシュ比較で差分検出、ONNXエンコーダによるベクトル生成、FTS・R\*Tree・ベクトルテーブルの更新をトランザクションで行います。【F:internal/ingest/ingest.go†L21-L178】【F:internal/ingest/ingest.go†L374-L515】
-- **埋め込みの永続化と類似度計算**: ベクトルはリトルエンディアンのBLOBへシリアライズして保存し、検索時にデシリアライズしてコサイン類似度でランキングします。【F:internal/vector/vector.go†L9-L32】【F:internal/vector/similarity.go†L5-L22】【F:internal/search/vector.go†L29-L129】
+- **SQLiteスキーマ**: `records`（メタデータ＋差分検出ハッシュ）、`records_vec`（埋め込みBLOB）、`records_fts`（全文検索）、`records_rtree`（位置情報）など、検索機能に必要な構造を用意しています。【F:internal/database/schema.go†L9-L40】
+- **CSV取り込みパイプライン**: 列の選択やメタデータ保持を柔軟に指定し、レコードごとのハッシュ比較で差分検出、ONNXエンコーダによるベクトル生成、FTS・R\*Tree・ベクトルテーブルの更新をトランザクションで行います。【F:internal/ingest/ingest.go†L22-L298】
+- **埋め込みの永続化と類似度計算**: ベクトルはリトルエンディアンのBLOBへシリアライズして保存し、検索時にデシリアライズしてコサイン類似度でランキングします。【F:internal/vector/vector.go†L9-L32】【F:internal/vector/similarity.go†L5-L22】【F:internal/search/vector.go†L25-L115】
 
 ## 使い方
 ### 1. ビルドと事前準備
@@ -26,14 +26,17 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
 ```bash
 ./csv-search ingest \
   --db ./data/app.db \
-  --csv ./sample/items.csv \
+  --csv ./sample/image.csv \
   --ort-lib ./onnxruntime/libonnxruntime.so \
   --model ./models/encoder.onnx \
   --tokenizer ./models/tokenizer.json \
-  --id-col id --title-col title --body-col body \
+  --table images \
+  --id-col image_id \
+  --text-cols "title,caption" \
+  --meta-cols "image_id,title,caption,path,tags" \
   --lat-col lat --lng-col lng --batch 1000
 ```
-列マッピングやバッチサイズを調整しつつ、変更があった行のみを再エンコードしてデータベースへ反映します。【F:main.go†L72-L155】【F:internal/ingest/ingest.go†L73-L178】【F:internal/ingest/ingest.go†L374-L515】
+テーブル名や埋め込み対象の列、保持するメタデータ列、緯度経度列、バッチサイズをCLIフラグで柔軟に指定しつつ、変更があった行のみを差分検出して再エンコードし、トランザクションで反映します。【F:main.go†L73-L145】【F:internal/ingest/ingest.go†L22-L298】
 
 ### 4. ベクトル検索
 ```bash
@@ -43,9 +46,10 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
   --topk 10 \
   --ort-lib ./onnxruntime/libonnxruntime.so \
   --model ./models/encoder.onnx \
-  --tokenizer ./models/tokenizer.json
+  --tokenizer ./models/tokenizer.json \
+  --table images
 ```
-クエリ文をエンコードしたベクトルと保存済みベクトルのコサイン類似度でランキングし、JSONで結果を取得できます。【F:main.go†L157-L210】【F:internal/search/vector.go†L29-L129】
+クエリ文をエンコードしたベクトルと指定したテーブルの保存済みベクトルのコサイン類似度でランキングし、関連メタデータを含むJSONで結果を取得できます。【F:main.go†L148-L203】【F:internal/search/vector.go†L25-L115】
 
 ## データフローと将来構想
 ディレクトリ構成や設定ファイルのアイデア、REST API・Web UI拡張、さらなるランキング強化など、今後の拡張計画も仕様書に整理されています。【F:basePlan.md†L201-L242】【F:basePlan.md†L255-L285】 優先実装順として、差分更新や検索パイプライン強化、フィルタリング、API化、Web UIの追加が計画されています。【F:basePlan.md†L276-L285】

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -8,41 +8,35 @@ import (
 
 var schema = []string{
 	"PRAGMA journal_mode=WAL;",
-	`CREATE TABLE IF NOT EXISTS items (
-                id TEXT PRIMARY KEY,
-                title TEXT,
-                body TEXT,
-                tags TEXT,
-                category TEXT,
-                price REAL,
-                stock INTEGER,
-                created_at INTEGER,
-                updated_at INTEGER,
+	`CREATE TABLE IF NOT EXISTS records (
+                dataset TEXT NOT NULL,
+                id TEXT NOT NULL,
+                data TEXT NOT NULL,
                 lat REAL,
                 lng REAL,
-                hash TEXT
+                hash TEXT,
+                PRIMARY KEY(dataset, id)
         );`,
-	`CREATE TABLE IF NOT EXISTS items_vec (
-                id TEXT PRIMARY KEY,
-                embedding BLOB NOT NULL
+	`CREATE TABLE IF NOT EXISTS records_vec (
+                dataset TEXT NOT NULL,
+                id TEXT NOT NULL,
+                embedding BLOB NOT NULL,
+                PRIMARY KEY(dataset, id),
+                FOREIGN KEY(dataset, id) REFERENCES records(dataset, id) ON DELETE CASCADE
         );`,
-	`CREATE VIRTUAL TABLE IF NOT EXISTS items_fts USING fts5(
+	`CREATE VIRTUAL TABLE IF NOT EXISTS records_fts USING fts5(
+                dataset UNINDEXED,
                 id UNINDEXED,
-                title,
-                body,
-                tags
+                content
         );`,
-	`CREATE VIRTUAL TABLE IF NOT EXISTS items_rtree USING rtree(
-                item_rowid,
+	`CREATE VIRTUAL TABLE IF NOT EXISTS records_rtree USING rtree(
+                rowid,
                 min_lat,
                 max_lat,
                 min_lng,
                 max_lng
         );`,
-	`CREATE INDEX IF NOT EXISTS idx_items_category ON items(category);`,
-	`CREATE INDEX IF NOT EXISTS idx_items_price ON items(price);`,
-	`CREATE INDEX IF NOT EXISTS idx_items_stock ON items(stock);`,
-	`CREATE INDEX IF NOT EXISTS idx_items_created_at ON items(created_at);`,
+	`CREATE INDEX IF NOT EXISTS idx_records_dataset ON records(dataset);`,
 }
 
 func applySchema(ctx context.Context, db *sql.DB, statements []string) error {


### PR DESCRIPTION
## Summary
- replace the fixed items schema with dataset-aware records/fts/vector tables
- refactor CSV ingestion to accept arbitrary text/metadata columns and configurable datasets via CLI
- update vector search and documentation to surface metadata results and document the new flags

## Testing
- go test ./... *(fails: missing go.sum entry for modernc.org/sqlite because the proxy is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccffe39fe88323b817db5380c6140d