### PR TITLE
Add config-driven CLI defaults and update usage

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,25 @@
+{
+  "database": {
+    "path": "./data/image.db"
+  },
+  "embedding": {
+    "ort_lib": "./onnixruntime-win/lib/onnxruntime.dll",
+    "model": "./models/bge-m3/model.onnx",
+    "tokenizer": "./models/bge-m3/tokenizer.json",
+    "max_seq_len": 512
+  },
+  "default_dataset": "textile_jobs",
+  "datasets": {
+    "textile_jobs": {
+      "table": "textile_jobs",
+      "csv": "./csv/image.csv",
+      "batch_size": 1000,
+      "id_column": "受付No",
+      "text_columns": ["実行内容"],
+      "meta_columns": ["*"]
+    }
+  },
+  "search": {
+    "default_topk": 5
+  }
+}

--- a/go.sum
+++ b/go.sum
@@ -28,3 +28,4 @@ golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+modernc.org/sqlite v1.27.0/go.mod h1:Qxpazz0zH8Z1xCFyi5GSL3FzbtZ3fvbjmywNogldEW0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,109 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Config represents application level settings loaded from a JSON file.
+type Config struct {
+	Database       DatabaseConfig           `json:"database"`
+	Embedding      EmbeddingConfig          `json:"embedding"`
+	DefaultDataset string                   `json:"default_dataset"`
+	Datasets       map[string]DatasetConfig `json:"datasets"`
+	Search         SearchConfig             `json:"search"`
+
+	baseDir string
+}
+
+// DatabaseConfig controls the SQLite database target.
+type DatabaseConfig struct {
+	Path string `json:"path"`
+}
+
+// EmbeddingConfig provides the ONNX runtime and encoder assets.
+type EmbeddingConfig struct {
+	OrtLib    string `json:"ort_lib"`
+	Model     string `json:"model"`
+	Tokenizer string `json:"tokenizer"`
+	MaxSeqLen int    `json:"max_seq_len"`
+}
+
+// DatasetConfig configures ingestion defaults for a named dataset/table.
+type DatasetConfig struct {
+	Table       string   `json:"table"`
+	CSV         string   `json:"csv"`
+	BatchSize   int      `json:"batch_size"`
+	IDColumn    string   `json:"id_column"`
+	TextColumns []string `json:"text_columns"`
+	MetaColumns []string `json:"meta_columns"`
+	LatColumn   string   `json:"lat_column"`
+	LngColumn   string   `json:"lng_column"`
+}
+
+// SearchConfig covers defaults for query behaviour.
+type SearchConfig struct {
+	DefaultTopK int `json:"default_topk"`
+}
+
+// Load reads a JSON configuration file from disk and validates its structure.
+func Load(path string) (*Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+
+	var cfg Config
+	if err := decoder.Decode(&cfg); err != nil {
+		if err == io.EOF {
+			return &cfg, nil
+		}
+		return nil, fmt.Errorf("decode config: %w", err)
+	}
+
+	// Ensure there is no trailing data in the config file.
+	if err := ensureEOF(decoder); err != nil {
+		return nil, err
+	}
+
+	cfg.baseDir = filepath.Dir(path)
+	return &cfg, nil
+}
+
+// Dataset retrieves the dataset configuration by name.
+func (cfg *Config) Dataset(name string) (DatasetConfig, bool) {
+	if cfg == nil {
+		return DatasetConfig{}, false
+	}
+	ds, ok := cfg.Datasets[name]
+	return ds, ok
+}
+
+// ResolvePath converts a potentially relative path into an absolute one using
+// the config file's directory as the base.
+func (cfg *Config) ResolvePath(value string) string {
+	if value == "" {
+		return ""
+	}
+	if filepath.IsAbs(value) || cfg == nil || cfg.baseDir == "" {
+		return value
+	}
+	return filepath.Clean(filepath.Join(cfg.baseDir, value))
+}
+
+func ensureEOF(decoder *json.Decoder) error {
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode config: unexpected trailing data")
+		}
+		return fmt.Errorf("decode config: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add a JSON configuration loader so init/ingest/search can share defaults
- teach each CLI command to read config.json (with override flags) and simplify options
- document the new workflow in USAGE.md and add a sample config.json

## Testing
- go test ./... *(fails: missing modernc.org/sqlite module in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0b0e88408323860d35e8e369116f