### PR TITLE
Add HTTP server mode for persistent encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ SemanticGeoSearchDBは、CSVファイルを取り込むだけでローカルのS
 CSVインポート → 差分検出・正規化 → ONNXによる埋め込み生成 → SQLite（records/records_vec/records_fts/records_rtree）への格納 → CLI/将来のAPIやUIからの検索という流れで動作します。【F:basePlan.md†L32-L52】【F:basePlan.md†L71-L111】 コア技術としてGo言語、SQLite（WAL/R\*Tree/FTS5）、ONNX Runtimeを採用し、クロスプラットフォームな単一バイナリ配布を想定しています。【F:basePlan.md†L56-L68】
 
 ## 実装済みの主な機能
-- **CLIコマンド**: `init`でスキーマ初期化、`ingest`でCSV取り込みと埋め込み生成、`search`でベクトル類似検索が実行できます。【F:main.go†L18-L224】
+- **CLIコマンド**: `init`でスキーマ初期化、`ingest`でCSV取り込みと埋め込み生成、`search`でベクトル類似検索が実行できます。【F:main.go†L18-L350】
 - **SQLiteスキーマ**: `records`（メタデータ＋差分検出ハッシュ）、`records_vec`（埋め込みBLOB）、`records_fts`（全文検索）、`records_rtree`（位置情報）など、検索機能に必要な構造を用意しています。【F:internal/database/schema.go†L9-L40】
 - **CSV取り込みパイプライン**: 列の選択やメタデータ保持を柔軟に指定し、レコードごとのハッシュ比較で差分検出、ONNXエンコーダによるベクトル生成、FTS・R\*Tree・ベクトルテーブルの更新をトランザクションで行います。【F:internal/ingest/ingest.go†L22-L298】
 - **埋め込みの永続化と類似度計算**: ベクトルはリトルエンディアンのBLOBへシリアライズして保存し、検索時にデシリアライズしてコサイン類似度でランキングします。【F:internal/vector/vector.go†L9-L32】【F:internal/vector/similarity.go†L5-L22】【F:internal/search/vector.go†L25-L115】
@@ -20,7 +20,7 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
 ```bash
 ./csv-search init --db ./data/app.db
 ```
-指定したパスにSQLiteデータベースを作成し、必要なテーブル・仮想テーブルを初期化します。【F:main.go†L49-L70】【F:internal/database/database.go†L14-L52】【F:internal/database/schema.go†L10-L45】
+指定したパスにSQLiteデータベースを作成し、必要なテーブル・仮想テーブルを初期化します。【F:main.go†L49-L88】【F:internal/database/database.go†L14-L52】【F:internal/database/schema.go†L10-L45】
 
 ### 3. CSV取り込み
 ```bash
@@ -36,7 +36,7 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
   --meta-cols "image_id,title,caption,path,tags" \
   --lat-col lat --lng-col lng --batch 1000
 ```
-テーブル名や埋め込み対象の列、保持するメタデータ列、緯度経度列、バッチサイズをCLIフラグで柔軟に指定しつつ、変更があった行のみを差分検出して再エンコードし、トランザクションで反映します。【F:main.go†L73-L145】【F:internal/ingest/ingest.go†L22-L298】
+テーブル名や埋め込み対象の列、保持するメタデータ列、緯度経度列、バッチサイズをCLIフラグで柔軟に指定しつつ、変更があった行のみを差分検出して再エンコードし、トランザクションで反映します。【F:main.go†L90-L224】【F:internal/ingest/ingest.go†L22-L298】
 
 ### 4. ベクトル検索
 ```bash
@@ -49,9 +49,30 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
   --tokenizer ./models/tokenizer.json \
   --table images
 ```
-クエリ文をエンコードしたベクトルと指定したテーブルの保存済みベクトルのコサイン類似度でランキングし、関連メタデータを含むJSONで結果を取得できます。【F:main.go†L148-L203】【F:internal/search/vector.go†L25-L115】
+クエリ文をエンコードしたベクトルと指定したテーブルの保存済みベクトルのコサイン類似度でランキングし、関連メタデータを含むJSONで結果を取得できます。【F:main.go†L353-L414】【F:internal/search/vector.go†L25-L115】
 
-検索対象に含まれる任意のメタデータ列で絞り込みたい場合は、`--filter "列名=値"` を繰り返し指定すると検索処理の内部で AND 条件として適用されます。例えば `--filter "得意先名=艶栄工業㈱"` を付与すると、該当する得意先名のレコードのみが結果に含まれます。【F:main.go†L211-L327】【F:internal/search/vector.go†L16-L114】
+検索対象に含まれる任意のメタデータ列で絞り込みたい場合は、`--filter "列名=値"` を繰り返し指定すると検索処理の内部で AND 条件として適用されます。例えば `--filter "得意先名=艶栄工業㈱"` を付与すると、該当する得意先名のレコードのみが結果に含まれます。【F:main.go†L365-L413】【F:internal/search/vector.go†L16-L114】
+
+### 5. サーバーモード（HTTP API）
+
+`serve` コマンドを使うと、設定ファイルやフラグで指定したデータベースとエンコーダー資産を読み込み、ONNX エンコーダーをメモリ上に保持したまま HTTP サーバーとして待機させられます。【F:main.go†L240-L350】【F:internal/server/server.go†L20-L162】 既定のデータセットやトップK件数、リクエストタイムアウトは `config.json` やフラグで上書きでき、停止シグナル受信時は安全にシャットダウンします。【F:main.go†L260-L350】【F:internal/server/server.go†L86-L105】
+
+```bash
+./csv-search serve \
+  --db ./data/app.db \
+  --addr :8080 \
+  --ort-lib ./onnxruntime/libonnxruntime.so \
+  --model ./models/encoder.onnx \
+  --tokenizer ./models/tokenizer.json
+```
+
+サーバー起動後は次のようなエンドポイントが利用できます。
+
+- `GET /search` — クエリ文字列 `q`（または `query`）、`topk`、`table`/`dataset`、`filter=列名=値` を指定して検索します。【F:internal/server/server.go†L166-L188】
+- `POST /search` — JSON で `{"query": "Wi-Fi カフェ", "dataset": "images", "topk": 5, "filters": {"得意先名": "艶栄工業㈱"}}` のように送信できます。【F:internal/server/server.go†L191-L226】
+- `GET /healthz` — ヘルスチェック用の軽量エンドポイントです。【F:internal/server/server.go†L108-L111】
+
+`filter` パラメータは CLI と同じく `フィールド=値` 形式を複数指定でき、JSON の `filters` マップと合わせて内部で AND 条件として処理されます。【F:internal/server/server.go†L120-L224】【F:internal/server/server.go†L229-L248】 レスポンスは CLI の `search` と同様に検索結果配列の JSON を返すため、既存のパイプラインにそのまま組み込めます。【F:internal/server/server.go†L150-L162】【F:internal/search/vector.go†L25-L115】
 
 ## データフローと将来構想
 ディレクトリ構成や設定ファイルのアイデア、REST API・Web UI拡張、さらなるランキング強化など、今後の拡張計画も仕様書に整理されています。【F:basePlan.md†L201-L242】【F:basePlan.md†L255-L285】 優先実装順として、差分更新や検索パイプライン強化、フィルタリング、API化、Web UIの追加が計画されています。【F:basePlan.md†L276-L285】

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,6 @@
 # USAGE
 
-本手順はリポジトリ同梱の`/csv/image.csv`を取り込み、列「実行内容」を意味検索の対象に設定したうえで、必要に応じて列「得意先名」でシステム内フィルタリングを行い、列「受付No」を含む行単位の検索結果を得るまでの流れを説明します。【F:csv/image.csv†L1-L16】【F:main.go†L85-L229】【F:main.go†L232-L329】
+本手順はリポジトリ同梱の`/csv/image.csv`を取り込み、列「実行内容」を意味検索の対象に設定したうえで、必要に応じて列「得意先名」でシステム内フィルタリングを行い、列「受付No」を含む行単位の検索結果を得るまでの流れを説明します。【F:csv/image.csv†L1-L16】【F:main.go†L90-L224】【F:main.go†L353-L414】
 
 ## 1. ビルドと前提ファイルの準備
 
@@ -13,24 +13,24 @@
 
 3. 実行時には以下のファイルを同じディレクトリか任意のパスに配置しておきます。
    - `csv-search`（ビルド済みバイナリ）【F:main.go†L20-L49】
-   - ONNX Runtime 共有ライブラリ `onnixruntime-win/lib/onnxruntime.dll`（`config.json` の `embedding.ort_lib` で参照）【F:config.json†L5-L9】【F:main.go†L164-L170】【F:main.go†L274-L280】
-   - エンコーダーモデル `models/bge-m3/model.onnx` と `model.onnx_data`【F:config.json†L5-L9】【F:main.go†L172-L178】【F:main.go†L282-L288】
-   - トークナイザ設定 `models/bge-m3/tokenizer.json`【F:config.json†L5-L9】【F:main.go†L180-L186】【F:main.go†L290-L296】
+   - ONNX Runtime 共有ライブラリ `onnixruntime-win/lib/onnxruntime.dll`（`config.json` の `embedding.ort_lib` で参照）【F:config.json†L5-L9】【F:main.go†L169-L175】【F:main.go†L279-L285】
+   - エンコーダーモデル `models/bge-m3/model.onnx` と `model.onnx_data`【F:config.json†L5-L9】【F:main.go†L177-L183】【F:main.go†L287-L293】
+   - トークナイザ設定 `models/bge-m3/tokenizer.json`【F:config.json†L5-L9】【F:main.go†L185-L191】【F:main.go†L295-L301】
    - 取り込み対象の CSV ファイル `/csv/image.csv`【F:config.json†L13-L20】【F:csv/image.csv†L1-L16】
 
 ## 2. `config.json` の確認とカスタマイズ
 
-リポジトリ直下に用意した `config.json` は、データベースの保存先や ONNX 関連ファイル、取り込み対象 CSV、デフォルトの検索トップ件数などをまとめて管理します。【F:config.json†L1-L24】 CLI コマンドは起動時にこのファイルを自動的に読み込み（存在しない場合は従来のフラグのみで動作）し、指定がないフラグ値を設定値で補います。【F:main.go†L51-L329】【F:internal/config/config.go†L12-L92】
+リポジトリ直下に用意した `config.json` は、データベースの保存先や ONNX 関連ファイル、取り込み対象 CSV、デフォルトの検索トップ件数などをまとめて管理します。【F:config.json†L1-L24】 CLI コマンドは起動時にこのファイルを自動的に読み込み（存在しない場合は従来のフラグのみで動作）し、指定がないフラグ値を設定値で補います。【F:main.go†L51-L414】【F:internal/config/config.go†L12-L92】
 
 主要な設定項目は次の通りです。
 
-- `database.path`: SQLite ファイルの出力先。【F:config.json†L2-L4】【F:main.go†L64-L142】【F:main.go†L268-L271】
-- `embedding` ブロック: ONNX Runtime DLL、エンコーダーモデル、トークナイザ、最大トークン長の既定値。【F:config.json†L5-L9】【F:main.go†L164-L188】【F:main.go†L274-L313】
-- `default_dataset`: `ingest` / `search` コマンドが参照する既定データセット名。【F:config.json†L11-L24】【F:main.go†L112-L268】
+- `database.path`: SQLite ファイルの出力先。【F:config.json†L2-L4】【F:main.go†L64-L147】【F:main.go†L274-L277】
+- `embedding` ブロック: ONNX Runtime DLL、エンコーダーモデル、トークナイザ、最大トークン長の既定値。【F:config.json†L5-L9】【F:main.go†L169-L207】【F:main.go†L279-L339】
+- `default_dataset`: `ingest` / `search` コマンドが参照する既定データセット名。【F:config.json†L11-L24】【F:main.go†L117-L206】【F:main.go†L260-L307】
 - `datasets.<name>`: CSV パス、ID 列、埋め込み対象列、保持するメタデータ列、バッチサイズなどの取り込み設定。【F:config.json†L13-L20】【F:main.go†L117-L160】
-- `search.default_topk`: 検索の既定件数。【F:config.json†L22-L24】【F:main.go†L298-L323】
+- `search.default_topk`: 検索の既定件数。【F:config.json†L22-L24】【F:main.go†L303-L339】
 
-複数のデータセットを扱う場合は `datasets` に別名を追加し、`default_dataset` を切り替えるか、コマンド実行時に `--table` で明示的に指定してください。【F:config.json†L11-L24】【F:main.go†L112-L161】【F:main.go†L232-L329】
+複数のデータセットを扱う場合は `datasets` に別名を追加し、`default_dataset` を切り替えるか、コマンド実行時に `--table` で明示的に指定してください。【F:config.json†L11-L24】【F:main.go†L117-L206】【F:main.go†L353-L414】
 
 ## 3. 初期化と CSV 取り込み
 
@@ -41,9 +41,9 @@
 ./csv-search ingest
 ```
 
-`init` は `database.path` に SQLite ファイルを作成し、スキーマを初期化します。【F:config.json†L2-L4】【F:main.go†L51-L83】【F:internal/database/schema.go†L10-L38】 `ingest` は `datasets.<name>` の設定を基に CSV を読み込み、必要な列から埋め込みを生成してレコード群を保存します。【F:config.json†L13-L20】【F:main.go†L85-L229】【F:internal/ingest/ingest.go†L22-L353】
+`init` は `database.path` に SQLite ファイルを作成し、スキーマを初期化します。【F:config.json†L2-L4】【F:main.go†L49-L88】【F:internal/database/schema.go†L10-L38】 `ingest` は `datasets.<name>` の設定を基に CSV を読み込み、必要な列から埋め込みを生成してレコード群を保存します。【F:config.json†L13-L20】【F:main.go†L90-L224】【F:internal/ingest/ingest.go†L22-L353】
 
-`config.json` 以外を使いたい場合は、`--config ./path/to/custom.json` を各コマンドに付与してください。個別のフラグ (`--db` や `--csv` など) を併用すると、その値が設定ファイルより優先されます。【F:main.go†L53-L229】
+`config.json` 以外を使いたい場合は、`--config ./path/to/custom.json` を各コマンドに付与してください。個別のフラグ (`--db` や `--csv` など) を併用すると、その値が設定ファイルより優先されます。【F:main.go†L53-L224】
 
 ## 4. 検索と結果の活用
 
@@ -53,7 +53,7 @@
 ./csv-search search --query "漂白"
 ```
 
-コマンドはクエリをエンコードし、保存済みベクトルとのコサイン類似度でランキングした JSON 配列を標準出力へ返します。結果には `fields` に「受付No」「得意先名」「実行内容」が含まれ、`id` としても「受付No」が保持されます。【F:main.go†L232-L329】【F:internal/search/vector.go†L25-L115】 `--topk`、`--table`、`--db` などを指定すると、設定ファイルの値を上書きできます。【F:main.go†L232-L329】
+コマンドはクエリをエンコードし、保存済みベクトルとのコサイン類似度でランキングした JSON 配列を標準出力へ返します。結果には `fields` に「受付No」「得意先名」「実行内容」が含まれ、`id` としても「受付No」が保持されます。【F:main.go†L353-L414】【F:internal/search/vector.go†L25-L115】 `--topk`、`--table`、`--db` などを指定すると、設定ファイルの値を上書きできます。【F:main.go†L353-L414】
 
 ### メタデータによるシステム内フィルタリング（得意先名）
 
@@ -63,7 +63,7 @@
 ./csv-search search --query "漂白" --filter "得意先名=艶栄工業㈱"
 ```
 
-フィルターは検索処理の内部で適用されるため、`jq` や `grep` など外部ツールに頼らずに目的の得意先名だけを抽出できます。複数条件を AND で組み合わせたい場合は `--filter` を繰り返し指定してください。【F:csv/image.csv†L1-L16】【F:internal/search/vector.go†L16-L114】【F:main.go†L211-L327】
+フィルターは検索処理の内部で適用されるため、`jq` や `grep` など外部ツールに頼らずに目的の得意先名だけを抽出できます。複数条件を AND で組み合わせたい場合は `--filter` を繰り返し指定してください。【F:csv/image.csv†L1-L16】【F:internal/search/vector.go†L16-L114】【F:main.go†L199-L413】
 
 ### 受付No を含む行出力の確認
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"yashubustudio/csv-search/emb"
+	"yashubustudio/csv-search/internal/search"
+)
+
+type Config struct {
+	Addr            string
+	Dataset         string
+	DefaultTopK     int
+	RequestTimeout  time.Duration
+	ShutdownTimeout time.Duration
+}
+
+type Server struct {
+	db       *sql.DB
+	enc      *emb.Encoder
+	cfg      Config
+	encodeMu sync.Mutex
+}
+
+func New(db *sql.DB, enc *emb.Encoder, cfg Config) (*Server, error) {
+	if db == nil {
+		return nil, fmt.Errorf("db must not be nil")
+	}
+	if enc == nil {
+		return nil, fmt.Errorf("encoder must not be nil")
+	}
+	cfg.Dataset = strings.TrimSpace(cfg.Dataset)
+	if cfg.Dataset == "" {
+		cfg.Dataset = "default"
+	}
+	cfg.Addr = strings.TrimSpace(cfg.Addr)
+	if cfg.Addr == "" {
+		cfg.Addr = ":8080"
+	}
+	if cfg.DefaultTopK <= 0 {
+		cfg.DefaultTopK = 10
+	}
+	if cfg.RequestTimeout <= 0 {
+		cfg.RequestTimeout = 30 * time.Second
+	}
+	if cfg.ShutdownTimeout <= 0 {
+		cfg.ShutdownTimeout = 5 * time.Second
+	}
+	return &Server{db: db, enc: enc, cfg: cfg}, nil
+}
+
+func (s *Server) Serve(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("context must not be nil")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search", s.handleSearch)
+	mux.HandleFunc("/healthz", s.handleHealth)
+
+	srv := &http.Server{
+		Addr:    s.cfg.Addr,
+		Handler: mux,
+	}
+
+	log.Printf("csv-search server listening on %s (dataset=%s, topK=%d)\n", s.cfg.Addr, s.cfg.Dataset, s.cfg.DefaultTopK)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), s.cfg.ShutdownTimeout)
+		defer cancel()
+
+		if err := srv.Shutdown(shutdownCtx); err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+		err := <-errCh
+		if err == nil || errors.Is(err, http.ErrServerClosed) {
+			log.Printf("csv-search server shutdown complete\n")
+			return nil
+		}
+		return err
+	case err := <-errCh:
+		if err == nil || errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+type searchRequest struct {
+	Query   string
+	Dataset string
+	TopK    int
+	Filters []search.Filter
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodPost:
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	req, err := s.decodeSearchRequest(r)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("query is required"))
+		return
+	}
+
+	dataset := req.Dataset
+	if dataset == "" {
+		dataset = s.cfg.Dataset
+	}
+	topK := req.TopK
+	if topK <= 0 {
+		topK = s.cfg.DefaultTopK
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), s.cfg.RequestTimeout)
+	defer cancel()
+
+	s.encodeMu.Lock()
+	results, err := search.VectorSearch(ctx, s.db, s.enc, dataset, req.Query, topK, req.Filters)
+	s.encodeMu.Unlock()
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, context.DeadlineExceeded) {
+			status = http.StatusGatewayTimeout
+		}
+		s.writeError(w, status, err)
+		return
+	}
+
+	s.writeJSON(w, http.StatusOK, results)
+}
+
+func (s *Server) decodeSearchRequest(r *http.Request) (searchRequest, error) {
+	if r.Method == http.MethodGet {
+		values := r.URL.Query()
+		query := strings.TrimSpace(values.Get("q"))
+		if query == "" {
+			query = strings.TrimSpace(values.Get("query"))
+		}
+		dataset := strings.TrimSpace(values.Get("dataset"))
+		if dataset == "" {
+			dataset = strings.TrimSpace(values.Get("table"))
+		}
+		topK := 0
+		if rawTopK := strings.TrimSpace(values.Get("topk")); rawTopK != "" {
+			v, err := strconv.Atoi(rawTopK)
+			if err != nil {
+				return searchRequest{}, fmt.Errorf("invalid topk value %q", rawTopK)
+			}
+			topK = v
+		}
+		filters, err := parseFilterValues(values["filter"])
+		if err != nil {
+			return searchRequest{}, err
+		}
+		return searchRequest{Query: query, Dataset: dataset, TopK: topK, Filters: filters}, nil
+	}
+
+	var payload struct {
+		Query   string            `json:"query"`
+		Dataset string            `json:"dataset"`
+		TopK    int               `json:"topk"`
+		Filters map[string]string `json:"filters"`
+		Filter  []string          `json:"filter"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&payload); err != nil {
+		return searchRequest{}, fmt.Errorf("decode request: %w", err)
+	}
+
+	req := searchRequest{
+		Query:   strings.TrimSpace(payload.Query),
+		Dataset: strings.TrimSpace(payload.Dataset),
+		TopK:    payload.TopK,
+	}
+	if len(payload.Filters) > 0 {
+		req.Filters = make([]search.Filter, 0, len(payload.Filters))
+		for k, v := range payload.Filters {
+			key := strings.TrimSpace(k)
+			if key == "" {
+				return searchRequest{}, fmt.Errorf("filter key must not be empty")
+			}
+			req.Filters = append(req.Filters, search.Filter{Field: key, Value: v})
+		}
+	}
+	if len(payload.Filter) > 0 {
+		extra, err := parseFilterValues(payload.Filter)
+		if err != nil {
+			return searchRequest{}, err
+		}
+		req.Filters = append(req.Filters, extra...)
+	}
+	return req, nil
+}
+
+func parseFilterValues(values []string) ([]search.Filter, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	filters := make([]search.Filter, 0, len(values))
+	for _, raw := range values {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("filter must be in the form field=value")
+		}
+		field := strings.TrimSpace(parts[0])
+		if field == "" {
+			return nil, fmt.Errorf("filter field must not be empty")
+		}
+		filters = append(filters, search.Filter{Field: field, Value: parts[1]})
+	}
+	return filters, nil
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	if status == http.StatusOK {
+		encoder.SetIndent("", "  ")
+	}
+	if err := encoder.Encode(v); err != nil {
+		log.Printf("writeJSON encode error: %v\n", err)
+	}
+}
+
+func (s *Server) writeError(w http.ResponseWriter, status int, err error) {
+	if err == nil {
+		err = fmt.Errorf("unknown error")
+	}
+	payload := map[string]string{"error": err.Error()}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if encodeErr := json.NewEncoder(w).Encode(payload); encodeErr != nil {
+		log.Printf("writeError encode error: %v\n", encodeErr)
+	}
+}


### PR DESCRIPTION
## Summary
- add a `serve` CLI command that keeps the ONNX encoder loaded and starts an HTTP search API
- implement an internal server package with search, filter, and health endpoints
- update README and USAGE documentation to describe the new server mode and refreshed CLI references

## Testing
- `go test ./...` *(fails: missing go.sum entry for modernc.org/sqlite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd145e0b748323b550794994fcd32e