### PR TITLE
Expose reusable service API and documentation

### DIFF
--- a/csv-search.md
+++ b/csv-search.md
@@ -1,0 +1,46 @@
+# csv-search Application Overview
+
+## 概要
+csv-search は CSV データを取り込み、ONNX Runtime を用いて文書ベクトルを生成し、SQLite に保存された埋め込みを使ってセマンティック検索を提供するアプリケーションです。CLI ツールとして単体で利用できるほか、`pkg/csvsearch` パッケージを経由して別の Go アプリケーションへ統合できます。
+
+## 主な機能
+- **データベース初期化**: SQLite スキーマの作成・更新。CLI の `init` サブコマンドおよび `Service.InitDatabase` で実施。【F:pkg/csvsearch/init.go†L7-L26】【F:main.go†L43-L73】
+- **CSV 取り込み**: CSV 行を読み込み、ONNX エンコーダーでテキストをベクトル化してデータベースへアップサート。`ingest` サブコマンドまたは `Service.Ingest` で利用可能。【F:pkg/csvsearch/ingest.go†L16-L121】【F:main.go†L75-L137】
+- **セマンティック検索**: クエリをベクトル化してコサイン類似度でランキング。`search` サブコマンドおよび `Service.Search` が提供し、結果は JSON 配列として取得できます。【F:pkg/csvsearch/search.go†L8-L70】【F:main.go†L139-L189】
+- **HTTP API サーバー**: REST エンドポイント (`/search`, `/healthz`) を提供。CLI の `serve` サブコマンドか `Service.StartServer` / `Service.NewAPIServer` で起動・統合可能。`internal/server.Server.Handler` により既存の HTTP サーバーへマウントすることもできます。【F:pkg/csvsearch/server.go†L7-L101】【F:internal/server/server.go†L70-L104】【F:main.go†L191-L240】
+
+## 必要なもの
+- **SQLite ドライバー**: `modernc.org/sqlite` を使用しており、CGO なしでビルド可能です。【F:pkg/csvsearch/service.go†L9-L11】【F:go.mod†L6-L13】
+- **ONNX Runtime DLL/共有ライブラリ**: `emb.Encoder` の `OrtDLL` へパスを指定する必要があります。Windows 向け `.dll` などを想定しています。【F:emb/emb.go†L1-L105】【F:pkg/csvsearch/service.go†L88-L116】
+- **エンコーダーモデル/トークナイザー**: ONNX モデル (`model.onnx`) と `tokenizer.json` を `EncoderConfig` または設定ファイルから指定。【F:pkg/csvsearch/service.go†L88-L116】【F:internal/config/config.go†L15-L52】
+- **設定ファイル (任意)**: `config.json` 形式でデータベースパス、エンコーディング資産、デフォルトデータセット、検索設定を定義できます。【F:internal/config/config.go†L11-L66】
+- **CSV データ**: 取り込み対象。デフォルトでは `id` 列とテキスト列（`text-cols` or `meta-cols`）が必要です。【F:pkg/csvsearch/ingest.go†L48-L103】
+
+## 入出力
+- **取り込み (`Ingest`) 入力**
+  - `IngestOptions` で CSV パス、ID 列、テキスト列、メタデータ列、緯度経度列などを指定。省略時は設定ファイルのデータセット定義が自動適用されます。【F:pkg/csvsearch/ingest.go†L16-L103】
+  - 出力として `IngestSummary` を返し、使用されたパラメータを参照できます。【F:pkg/csvsearch/ingest.go†L18-L27】【F:pkg/csvsearch/ingest.go†L105-L121】
+- **検索 (`Search`) 入力/出力**
+  - `SearchOptions` はクエリ文字列、対象データセット、TopK、フィルター（`Filter` 構造体）を受け取ります。【F:pkg/csvsearch/search.go†L24-L37】
+  - 戻り値は `Result` のスライスで、ID・スコア・メタデータ・位置情報を含む JSON 互換構造です。【F:pkg/csvsearch/search.go†L10-L22】【F:pkg/csvsearch/search.go†L39-L68】
+- **HTTP API**
+  - `/search`: GET/POST 共通。`q`/`query`、`dataset`/`table`、`topk`、`filter=field=value` をサポート。【F:internal/server/server.go†L96-L165】
+  - `/healthz`: サーバーヘルスチェック用。常に `200 OK` を返します。【F:internal/server/server.go†L88-L94】
+
+## Go 統合ポイント
+- **Service 構築**: `NewService(ServiceOptions)` で設定・DB・エンコーダー（遅延初期化）を一括管理。外部から提供された DB/エンコーダーを再利用できます。【F:pkg/csvsearch/service.go†L33-L117】
+- **データベースパス取得**: `Service.DatabasePath()` で実際に使用している SQLite ファイルのパスを取得可能（外部接続時は空文字）。【F:pkg/csvsearch/service.go†L61-L68】
+- **HTTP 統合**: `APIServer.Handler()` を既存ルーターに登録、または `APIServer.Serve(ctx)` で単独起動。【F:pkg/csvsearch/server.go†L23-L55】
+- **Graceful Shutdown**: `StartServer` は `context.Context` を介して OS シグナルなどに対応し、自動でデータセットを取り込みます（設定に CSV パスがある場合）。【F:pkg/csvsearch/server.go†L57-L101】
+
+## CLI サブコマンド概要
+| コマンド | 主なオプション | 概要 |
+|----------|----------------|------|
+| `init`   | `--config`, `--db` | SQLite スキーマ初期化。デフォルトは `config.json` と `data/app.db`。【F:main.go†L43-L73】 |
+| `ingest` | `--csv`, `--table`, `--text-cols`, `--meta-cols`, `--lat-col`, `--lng-col`, `--ort-lib`, `--model`, `--tokenizer`, `--max-seq-len` | CSV を読み込みベクトル化し保存。終了後に取り込み概要を出力。【F:main.go†L75-L137】 |
+| `search` | `--query`, `--table`, `--topk`, `--filter`, エンコーダー関連オプション | クエリを検索し、JSON 形式で結果を標準出力。【F:main.go†L139-L189】 |
+| `serve`  | `--addr`, `--table`, `--topk`, `--request-timeout`, `--shutdown-timeout`, エンコーダー関連オプション | HTTP API サーバーを起動。Ctrl+C などでグレースフル終了。【F:main.go†L191-L240】 |
+
+## ビルドに関する注意
+- Windows 向け `.exe` ビルドを想定する場合、`GOOS=windows` とし、`EncoderConfig` の `OrtLibrary` に ONNX Runtime の DLL を指定してください。`modernc.org/sqlite` を採用しているため、CGO 無効のままクロスビルドが可能です。【F:pkg/csvsearch/service.go†L9-L11】【F:pkg/csvsearch/service.go†L88-L116】
+- ONNX ランタイム DLL、モデルファイル、トークナイザーをアプリと同じディレクトリに配置するか、設定ファイルで絶対パス/相対パスを指定してください。【F:internal/config/config.go†L40-L52】【F:pkg/csvsearch/service.go†L88-L116】

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,13 +63,10 @@ func (s *Server) Serve(ctx context.Context) error {
 	if ctx == nil {
 		return fmt.Errorf("context must not be nil")
 	}
-	mux := http.NewServeMux()
-	mux.HandleFunc("/search", s.handleSearch)
-	mux.HandleFunc("/healthz", s.handleHealth)
-
+	handler := s.Handler()
 	srv := &http.Server{
 		Addr:    s.cfg.Addr,
-		Handler: mux,
+		Handler: handler,
 	}
 
 	log.Printf("csv-search server listening on %s (dataset=%s, topK=%d)\n", s.cfg.Addr, s.cfg.Dataset, s.cfg.DefaultTopK)
@@ -103,6 +100,15 @@ func (s *Server) Serve(ctx context.Context) error {
 		}
 		return err
 	}
+}
+
+// Handler builds a new http.Handler exposing the search and health endpoints.
+// Callers can mount the handler on an existing mux when embedding the service.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search", s.handleSearch)
+	mux.HandleFunc("/healthz", s.handleHealth)
+	return mux
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {

--- a/pkg/csvsearch/helpers.go
+++ b/pkg/csvsearch/helpers.go
@@ -1,0 +1,81 @@
+package csvsearch
+
+import (
+	"os"
+	"strings"
+
+	"yashubustudio/csv-search/internal/config"
+)
+
+func loadConfig(path string, required bool) (*config.Config, error) {
+	normalized := strings.TrimSpace(path)
+	if normalized == "" {
+		normalized = "config.json"
+	}
+	cfg, err := config.Load(normalized)
+	if err != nil {
+		if os.IsNotExist(err) && !required {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func configDatabasePath(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.ResolvePath(cfg.Database.Path)
+}
+
+func cfgSearchTopK(cfg *config.Config) int {
+	if cfg == nil {
+		return 0
+	}
+	return cfg.Search.DefaultTopK
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstPositive(values ...int) int {
+	for _, v := range values {
+		if v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+func cloneStrings(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]string, len(src))
+	copy(out, src)
+	return out
+}
+
+func resolveDataset(cfg *config.Config, name string) (string, config.DatasetConfig, bool) {
+	datasetName := strings.TrimSpace(name)
+	if datasetName == "" && cfg != nil && cfg.DefaultDataset != "" {
+		datasetName = cfg.DefaultDataset
+	}
+	if cfg != nil && datasetName != "" {
+		if ds, ok := cfg.Dataset(datasetName); ok {
+			return datasetName, ds, true
+		}
+	}
+	return datasetName, config.DatasetConfig{}, false
+}
+
+func resolveTable(datasetName string, dataset config.DatasetConfig, override string) string {
+	return firstNonEmpty(strings.TrimSpace(override), dataset.Table, datasetName, "default")
+}

--- a/pkg/csvsearch/ingest.go
+++ b/pkg/csvsearch/ingest.go
@@ -1,0 +1,120 @@
+package csvsearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"yashubustudio/csv-search/internal/ingest"
+)
+
+// IngestOptions configure CSV ingestion for a logical dataset.
+type IngestOptions struct {
+	Dataset         string
+	Table           string
+	CSVPath         string
+	BatchSize       int
+	IDColumn        string
+	TextColumns     []string
+	MetadataColumns []string
+	LatitudeColumn  string
+	LongitudeColumn string
+}
+
+// IngestSummary describes the resolved ingestion parameters that were applied.
+type IngestSummary struct {
+	Dataset         string
+	Table           string
+	CSVPath         string
+	BatchSize       int
+	IDColumn        string
+	TextColumns     []string
+	MetadataColumns []string
+	LatitudeColumn  string
+	LongitudeColumn string
+}
+
+// Ingest reads a CSV file, generates embeddings and upserts records into the
+// SQLite database managed by the Service.
+func (s *Service) Ingest(ctx context.Context, opts IngestOptions) (IngestSummary, error) {
+	if ctx == nil {
+		return IngestSummary{}, fmt.Errorf("context must not be nil")
+	}
+	if s.db == nil {
+		return IngestSummary{}, fmt.Errorf("database handle is nil")
+	}
+
+	datasetName, dataset, hasDataset := resolveDataset(s.cfg, opts.Dataset)
+	table := resolveTable(datasetName, dataset, opts.Table)
+
+	csvPath := strings.TrimSpace(opts.CSVPath)
+	if csvPath == "" && hasDataset {
+		csvPath = dataset.CSV
+	}
+	if s.cfg != nil {
+		csvPath = s.cfg.ResolvePath(csvPath)
+	}
+	if csvPath == "" {
+		return IngestSummary{}, fmt.Errorf("csv path is required")
+	}
+
+	batchSize := firstPositive(opts.BatchSize, dataset.BatchSize, 1000)
+	identifier := firstNonEmpty(strings.TrimSpace(opts.IDColumn), dataset.IDColumn, "id")
+
+	textCols := cloneStrings(opts.TextColumns)
+	if len(textCols) == 0 && hasDataset && len(dataset.TextColumns) > 0 {
+		textCols = cloneStrings(dataset.TextColumns)
+	}
+
+	metaCols := cloneStrings(opts.MetadataColumns)
+	if len(metaCols) == 0 {
+		if hasDataset && len(dataset.MetaColumns) > 0 {
+			metaCols = cloneStrings(dataset.MetaColumns)
+		} else {
+			metaCols = []string{"*"}
+		}
+	}
+
+	latitude := firstNonEmpty(strings.TrimSpace(opts.LatitudeColumn), dataset.LatColumn)
+	longitude := firstNonEmpty(strings.TrimSpace(opts.LongitudeColumn), dataset.LngColumn)
+
+	if err := s.InitDatabase(ctx, InitDatabaseOptions{}); err != nil {
+		return IngestSummary{}, err
+	}
+
+	enc, err := s.ensureEncoder()
+	if err != nil {
+		return IngestSummary{}, err
+	}
+
+	ingestOpts := ingest.Options{
+		CSVPath:   csvPath,
+		BatchSize: batchSize,
+		Dataset:   table,
+		Columns: ingest.ColumnConfig{
+			ID:       identifier,
+			Text:     textCols,
+			Metadata: metaCols,
+			Lat:      latitude,
+			Lng:      longitude,
+		},
+	}
+
+	if err := ingest.Run(ctx, s.db, enc, ingestOpts); err != nil {
+		return IngestSummary{}, err
+	}
+
+	summary := IngestSummary{
+		Dataset:         datasetName,
+		Table:           table,
+		CSVPath:         csvPath,
+		BatchSize:       batchSize,
+		IDColumn:        identifier,
+		TextColumns:     cloneStrings(textCols),
+		MetadataColumns: cloneStrings(metaCols),
+		LatitudeColumn:  latitude,
+		LongitudeColumn: longitude,
+	}
+
+	return summary, nil
+}

--- a/pkg/csvsearch/init.go
+++ b/pkg/csvsearch/init.go
@@ -1,0 +1,35 @@
+package csvsearch
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"yashubustudio/csv-search/internal/database"
+)
+
+// InitDatabaseOptions control database schema initialization.
+type InitDatabaseOptions struct {
+	Timeout time.Duration
+}
+
+// InitDatabase ensures that the SQLite schema exists. The method respects the
+// provided timeout (defaulting to 10 seconds) and can be called multiple times.
+func (s *Service) InitDatabase(ctx context.Context, opts InitDatabaseOptions) error {
+	if ctx == nil {
+		return fmt.Errorf("context must not be nil")
+	}
+	if s.db == nil {
+		return fmt.Errorf("database handle is nil")
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	initCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return database.Init(initCtx, s.db)
+}

--- a/pkg/csvsearch/search.go
+++ b/pkg/csvsearch/search.go
@@ -1,0 +1,86 @@
+package csvsearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	intsearch "yashubustudio/csv-search/internal/search"
+)
+
+// Filter represents a metadata equality condition applied to search results.
+type Filter struct {
+	Field string
+	Value string
+}
+
+// Result mirrors the JSON structure returned by the HTTP API and search
+// subcommand.
+type Result struct {
+	Dataset string            `json:"dataset"`
+	ID      string            `json:"id"`
+	Fields  map[string]string `json:"fields,omitempty"`
+	Score   float64           `json:"score"`
+	Lat     *float64          `json:"lat,omitempty"`
+	Lng     *float64          `json:"lng,omitempty"`
+}
+
+// SearchOptions describe how to run a semantic search request against the
+// embedded vector index.
+type SearchOptions struct {
+	Query   string
+	Dataset string
+	Table   string
+	TopK    int
+	Filters []Filter
+}
+
+// Search encodes the query with the ONNX encoder and performs cosine similarity
+// ranking against the stored vectors.
+func (s *Service) Search(ctx context.Context, opts SearchOptions) ([]Result, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context must not be nil")
+	}
+	if s.db == nil {
+		return nil, fmt.Errorf("database handle is nil")
+	}
+	if strings.TrimSpace(opts.Query) == "" {
+		return nil, fmt.Errorf("query is required")
+	}
+
+	datasetName, dataset, _ := resolveDataset(s.cfg, opts.Dataset)
+	table := resolveTable(datasetName, dataset, opts.Table)
+	limit := firstPositive(opts.TopK, cfgSearchTopK(s.cfg), 10)
+
+	enc, err := s.ensureEncoder()
+	if err != nil {
+		return nil, err
+	}
+
+	filters := make([]intsearch.Filter, 0, len(opts.Filters))
+	for _, f := range opts.Filters {
+		field := strings.TrimSpace(f.Field)
+		if field == "" {
+			continue
+		}
+		filters = append(filters, intsearch.Filter{Field: field, Value: f.Value})
+	}
+
+	results, err := intsearch.VectorSearch(ctx, s.db, enc, table, opts.Query, limit, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	converted := make([]Result, len(results))
+	for i, r := range results {
+		converted[i] = Result{
+			Dataset: r.Dataset,
+			ID:      r.ID,
+			Fields:  r.Fields,
+			Score:   r.Score,
+			Lat:     r.Lat,
+			Lng:     r.Lng,
+		}
+	}
+	return converted, nil
+}

--- a/pkg/csvsearch/server.go
+++ b/pkg/csvsearch/server.go
@@ -1,0 +1,127 @@
+package csvsearch
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"yashubustudio/csv-search/internal/server"
+)
+
+// ServeOptions configure the HTTP API server exposed by the Service.
+type ServeOptions struct {
+	Address         string
+	Dataset         string
+	Table           string
+	TopK            int
+	RequestTimeout  time.Duration
+	ShutdownTimeout time.Duration
+	AutoIngest      *bool
+}
+
+// APIServer wraps the internal server.Server to provide a stable API surface for
+// applications embedding csv-search.
+type APIServer struct {
+	server *server.Server
+}
+
+// Handler exposes the HTTP handler so that callers can mount it on an existing
+// http.Server or router.
+func (s *APIServer) Handler() http.Handler {
+	if s == nil || s.server == nil {
+		return nil
+	}
+	return s.server.Handler()
+}
+
+// Serve starts the HTTP server using the provided context for shutdown signals.
+func (s *APIServer) Serve(ctx context.Context) error {
+	if s == nil {
+		return fmt.Errorf("server is nil")
+	}
+	return s.server.Serve(ctx)
+}
+
+// NewAPIServer prepares the HTTP API server using the provided options. The
+// caller is responsible for ensuring the database schema exists (use
+// InitDatabase) and ingesting data before serving traffic.
+func (s *Service) NewAPIServer(opts ServeOptions) (*APIServer, error) {
+	if s.db == nil {
+		return nil, fmt.Errorf("database handle is nil")
+	}
+
+	datasetName, datasetCfg, _ := resolveDataset(s.cfg, opts.Dataset)
+	table := resolveTable(datasetName, datasetCfg, opts.Table)
+	defaultTopK := firstPositive(opts.TopK, cfgSearchTopK(s.cfg), 10)
+
+	reqTimeout := opts.RequestTimeout
+	if reqTimeout <= 0 {
+		reqTimeout = 30 * time.Second
+	}
+	shutdownTimeout := opts.ShutdownTimeout
+	if shutdownTimeout <= 0 {
+		shutdownTimeout = 5 * time.Second
+	}
+
+	addr := firstNonEmpty(strings.TrimSpace(opts.Address), ":8080")
+
+	enc, err := s.ensureEncoder()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := server.Config{
+		Addr:            addr,
+		Dataset:         table,
+		DefaultTopK:     defaultTopK,
+		RequestTimeout:  reqTimeout,
+		ShutdownTimeout: shutdownTimeout,
+	}
+
+	srv, err := server.New(s.db, enc, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &APIServer{server: srv}, nil
+}
+
+// StartServer optionally ingests data from the configuration and starts the HTTP
+// server until the context is cancelled.
+func (s *Service) StartServer(ctx context.Context, opts ServeOptions) error {
+	if ctx == nil {
+		return fmt.Errorf("context must not be nil")
+	}
+
+	if err := s.InitDatabase(ctx, InitDatabaseOptions{}); err != nil {
+		return err
+	}
+
+	datasetName, datasetCfg, hasDataset := resolveDataset(s.cfg, opts.Dataset)
+	table := resolveTable(datasetName, datasetCfg, opts.Table)
+
+	autoIngest := true
+	if opts.AutoIngest != nil {
+		autoIngest = *opts.AutoIngest
+	}
+
+	if autoIngest && hasDataset && strings.TrimSpace(datasetCfg.CSV) != "" {
+		if _, err := s.Ingest(ctx, IngestOptions{Dataset: datasetName, Table: table}); err != nil {
+			return err
+		}
+	}
+
+	apiServer, err := s.NewAPIServer(ServeOptions{
+		Address:         opts.Address,
+		Dataset:         datasetName,
+		Table:           table,
+		TopK:            opts.TopK,
+		RequestTimeout:  opts.RequestTimeout,
+		ShutdownTimeout: opts.ShutdownTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	return apiServer.Serve(ctx)
+}

--- a/pkg/csvsearch/service.go
+++ b/pkg/csvsearch/service.go
@@ -1,0 +1,194 @@
+package csvsearch
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"yashubustudio/csv-search/emb"
+	"yashubustudio/csv-search/internal/config"
+	"yashubustudio/csv-search/internal/database"
+)
+
+// ConfigReference describes how to load an optional JSON configuration file.
+type ConfigReference struct {
+	Path     string
+	Required bool
+}
+
+// DatabaseOptions allows callers to reuse an existing *sql.DB or request the
+// library to open one from the provided path.
+type DatabaseOptions struct {
+	Path   string
+	Handle *sql.DB
+}
+
+// EncoderConfig lists the assets required to initialize the ONNX encoder.
+type EncoderConfig struct {
+	OrtLibrary        string
+	ModelPath         string
+	TokenizerPath     string
+	MaxSequenceLength int
+}
+
+// EncoderOptions lets callers pass a pre-configured encoder or request the
+// library to lazily create one from EncoderConfig or the JSON configuration.
+type EncoderOptions struct {
+	Instance *emb.Encoder
+	Config   EncoderConfig
+}
+
+// ServiceOptions groups the dependencies required to build a Service.
+type ServiceOptions struct {
+	Config   ConfigReference
+	Database DatabaseOptions
+	Encoder  EncoderOptions
+}
+
+// Service exposes high level helpers that can be embedded into another Go
+// application. The struct owns the database and encoder resources when it
+// creates them and will release them on Close.
+type Service struct {
+	cfg          *config.Config
+	db           *sql.DB
+	dbPath       string
+	closeDB      bool
+	encoder      *emb.Encoder
+	closeEncoder bool
+	encoderCfg   EncoderConfig
+}
+
+// NewService loads the optional JSON configuration file, opens the database (if
+// Handle is nil) and stores encoder configuration for lazy initialization.
+func NewService(opts ServiceOptions) (*Service, error) {
+	cfg, err := loadConfig(opts.Config.Path, opts.Config.Required)
+	if err != nil {
+		return nil, err
+	}
+
+	db, dbPath, closeDB, err := prepareDatabase(cfg, opts.Database)
+	if err != nil {
+		return nil, err
+	}
+
+	svc := &Service{
+		cfg:          cfg,
+		db:           db,
+		dbPath:       dbPath,
+		closeDB:      closeDB,
+		encoder:      opts.Encoder.Instance,
+		closeEncoder: opts.Encoder.Instance == nil && (opts.Encoder.Config != EncoderConfig{}),
+	}
+
+	svc.encoderCfg = resolveEncoderConfig(cfg, opts.Encoder.Config)
+	if svc.encoder != nil {
+		svc.closeEncoder = false
+	}
+
+	return svc, nil
+}
+
+// Close releases any resources that were created by the Service instance.
+func (s *Service) Close() error {
+	var firstErr error
+	if s.closeEncoder && s.encoder != nil {
+		s.encoder.Close()
+		s.encoder = nil
+	}
+	if s.closeDB && s.db != nil {
+		if err := s.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		s.db = nil
+		s.dbPath = ""
+	}
+	return firstErr
+}
+
+// Config returns the loaded configuration (if any).
+func (s *Service) Config() *config.Config {
+	return s.cfg
+}
+
+// DB exposes the underlying database handle.
+func (s *Service) DB() *sql.DB {
+	return s.db
+}
+
+// DatabasePath returns the resolved filesystem path backing the SQLite
+// connection when available.
+func (s *Service) DatabasePath() string {
+	return s.dbPath
+}
+
+// Encoder returns the lazily created encoder instance, initializing it if
+// necessary.
+func (s *Service) Encoder() (*emb.Encoder, error) {
+	return s.ensureEncoder()
+}
+
+func prepareDatabase(cfg *config.Config, opts DatabaseOptions) (*sql.DB, string, bool, error) {
+	if opts.Handle != nil {
+		return opts.Handle, strings.TrimSpace(opts.Path), false, nil
+	}
+	path := firstNonEmpty(strings.TrimSpace(opts.Path), configDatabasePath(cfg), "data/app.db")
+	if path == "" {
+		return nil, "", false, fmt.Errorf("database path is required")
+	}
+	db, err := database.Open(path)
+	if err != nil {
+		return nil, path, false, err
+	}
+	return db, path, true, nil
+}
+
+func resolveEncoderConfig(cfg *config.Config, opts EncoderConfig) EncoderConfig {
+	resolved := EncoderConfig{}
+	if cfg != nil {
+		resolved.OrtLibrary = cfg.ResolvePath(cfg.Embedding.OrtLib)
+		resolved.ModelPath = cfg.ResolvePath(cfg.Embedding.Model)
+		resolved.TokenizerPath = cfg.ResolvePath(cfg.Embedding.Tokenizer)
+		resolved.MaxSequenceLength = cfg.Embedding.MaxSeqLen
+	}
+
+	if opts.OrtLibrary != "" {
+		resolved.OrtLibrary = opts.OrtLibrary
+	}
+	if opts.ModelPath != "" {
+		resolved.ModelPath = opts.ModelPath
+	}
+	if opts.TokenizerPath != "" {
+		resolved.TokenizerPath = opts.TokenizerPath
+	}
+	if opts.MaxSequenceLength > 0 {
+		resolved.MaxSequenceLength = opts.MaxSequenceLength
+	}
+
+	return resolved
+}
+
+func (s *Service) ensureEncoder() (*emb.Encoder, error) {
+	if s.encoder != nil {
+		return s.encoder, nil
+	}
+
+	cfg := s.encoderCfg
+	if cfg.OrtLibrary == "" || cfg.ModelPath == "" || cfg.TokenizerPath == "" {
+		return nil, fmt.Errorf("encoder configuration is incomplete")
+	}
+
+	enc := &emb.Encoder{}
+	encoderCfg := emb.Config{
+		OrtDLL:        cfg.OrtLibrary,
+		ModelPath:     cfg.ModelPath,
+		TokenizerPath: cfg.TokenizerPath,
+		MaxSeqLen:     cfg.MaxSequenceLength,
+	}
+	if err := enc.Init(encoderCfg); err != nil {
+		return nil, err
+	}
+
+	s.encoder = enc
+	s.closeEncoder = true
+	return enc, nil
+}


### PR DESCRIPTION
## Summary
- add a public `pkg/csvsearch` package with a reusable `Service` API for init, ingest, search, and HTTP serving
- refactor the CLI to consume the new service layer and report ingestion summaries
- expose a reusable HTTP handler and document the project features and requirements in csv-search.md

## Testing
- `go test ./...` *(fails: unable to download modules from proxy.golang.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdce1b91148323bded04bba24a30ef