### PR TITLE
Remove inline reference brackets from markdown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # SemanticGeoSearchDB (csv-search)
 
 ## 概要
-SemanticGeoSearchDBは、CSVファイルを取り込むだけでローカルのSQLiteデータベースへ正規化・差分同期し、テキストと位置情報を活用した高度な検索を単体パッケージで提供することを目指すプロジェクトです。【F:basePlan.md†L3-L24】 ネットワーク接続やクラウドサービスに依存せず、エンドユーザーが即座に検索環境を構築できることを目的としています。【F:basePlan.md†L12-L24】
+SemanticGeoSearchDBは、CSVファイルを取り込むだけでローカルのSQLiteデータベースへ正規化・差分同期し、テキストと位置情報を活用した高度な検索を単体パッケージで提供することを目指すプロジェクトです。 ネットワーク接続やクラウドサービスに依存せず、エンドユーザーが即座に検索環境を構築できることを目的としています。
 
 ## コンセプトとシステム構成
-CSVインポート → 差分検出・正規化 → ONNXによる埋め込み生成 → SQLite（records/records_vec/records_fts/records_rtree）への格納 → CLI/将来のAPIやUIからの検索という流れで動作します。【F:basePlan.md†L32-L52】【F:basePlan.md†L71-L111】 コア技術としてGo言語、SQLite（WAL/R\*Tree/FTS5）、ONNX Runtimeを採用し、クロスプラットフォームな単一バイナリ配布を想定しています。【F:basePlan.md†L56-L68】
+CSVインポート → 差分検出・正規化 → ONNXによる埋め込み生成 → SQLite（records/records_vec/records_fts/records_rtree）への格納 → CLI/将来のAPIやUIからの検索という流れで動作します。 コア技術としてGo言語、SQLite（WAL/R\*Tree/FTS5）、ONNX Runtimeを採用し、クロスプラットフォームな単一バイナリ配布を想定しています。
 
 ## 実装済みの主な機能
-- **CLIコマンド**: `init`でスキーマ初期化、`ingest`でCSV取り込みと埋め込み生成、`search`でベクトル類似検索が実行できます。【F:main.go†L18-L350】
-- **SQLiteスキーマ**: `records`（メタデータ＋差分検出ハッシュ）、`records_vec`（埋め込みBLOB）、`records_fts`（全文検索）、`records_rtree`（位置情報）など、検索機能に必要な構造を用意しています。【F:internal/database/schema.go†L9-L40】
-- **CSV取り込みパイプライン**: 列の選択やメタデータ保持を柔軟に指定し、レコードごとのハッシュ比較で差分検出、ONNXエンコーダによるベクトル生成、FTS・R\*Tree・ベクトルテーブルの更新をトランザクションで行います。【F:internal/ingest/ingest.go†L22-L298】
-- **埋め込みの永続化と類似度計算**: ベクトルはリトルエンディアンのBLOBへシリアライズして保存し、検索時にデシリアライズしてコサイン類似度でランキングします。【F:internal/vector/vector.go†L9-L32】【F:internal/vector/similarity.go†L5-L22】【F:internal/search/vector.go†L25-L115】
+- **CLIコマンド**: `init`でスキーマ初期化、`ingest`でCSV取り込みと埋め込み生成、`search`でベクトル類似検索が実行できます。
+- **SQLiteスキーマ**: `records`（メタデータ＋差分検出ハッシュ）、`records_vec`（埋め込みBLOB）、`records_fts`（全文検索）、`records_rtree`（位置情報）など、検索機能に必要な構造を用意しています。
+- **CSV取り込みパイプライン**: 列の選択やメタデータ保持を柔軟に指定し、レコードごとのハッシュ比較で差分検出、ONNXエンコーダによるベクトル生成、FTS・R\*Tree・ベクトルテーブルの更新をトランザクションで行います。
+- **埋め込みの永続化と類似度計算**: ベクトルはリトルエンディアンのBLOBへシリアライズして保存し、検索時にデシリアライズしてコサイン類似度でランキングします。
 
 ## 使い方
 ### 1. ビルドと事前準備
-Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダモデル、トークナイザファイルを用意してください。本プロジェクトは`sugarme/tokenizer`、`yalue/onnxruntime_go`、`modernc.org/sqlite`などの依存関係を利用します。【F:go.mod†L5-L19】 バイナリは`go build`で生成できます。【F:basePlan.md†L246-L251】
+Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダモデル、トークナイザファイルを用意してください。本プロジェクトは`sugarme/tokenizer`、`yalue/onnxruntime_go`、`modernc.org/sqlite`などの依存関係を利用します。 バイナリは`go build`で生成できます。
 
 ### 2. データベース初期化
 ```bash
 ./csv-search init --db ./data/app.db
 ```
-指定したパスにSQLiteデータベースを作成し、必要なテーブル・仮想テーブルを初期化します。【F:main.go†L49-L88】【F:internal/database/database.go†L14-L52】【F:internal/database/schema.go†L10-L45】
+指定したパスにSQLiteデータベースを作成し、必要なテーブル・仮想テーブルを初期化します。
 
 ### 3. CSV取り込み
 ```bash
@@ -36,7 +36,7 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
   --meta-cols "image_id,title,caption,path,tags" \
   --lat-col lat --lng-col lng --batch 1000
 ```
-テーブル名や埋め込み対象の列、保持するメタデータ列、緯度経度列、バッチサイズをCLIフラグで柔軟に指定しつつ、変更があった行のみを差分検出して再エンコードし、トランザクションで反映します。【F:main.go†L90-L224】【F:internal/ingest/ingest.go†L22-L298】
+テーブル名や埋め込み対象の列、保持するメタデータ列、緯度経度列、バッチサイズをCLIフラグで柔軟に指定しつつ、変更があった行のみを差分検出して再エンコードし、トランザクションで反映します。
 
 ### 4. ベクトル検索
 ```bash
@@ -49,13 +49,13 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
   --tokenizer ./models/tokenizer.json \
   --table images
 ```
-クエリ文をエンコードしたベクトルと指定したテーブルの保存済みベクトルのコサイン類似度でランキングし、関連メタデータを含むJSONで結果を取得できます。【F:main.go†L353-L414】【F:internal/search/vector.go†L25-L115】
+クエリ文をエンコードしたベクトルと指定したテーブルの保存済みベクトルのコサイン類似度でランキングし、関連メタデータを含むJSONで結果を取得できます。
 
-検索対象に含まれる任意のメタデータ列で絞り込みたい場合は、`--filter "列名=値"` を繰り返し指定すると検索処理の内部で AND 条件として適用されます。例えば `--filter "得意先名=艶栄工業㈱"` を付与すると、該当する得意先名のレコードのみが結果に含まれます。【F:main.go†L365-L413】【F:internal/search/vector.go†L16-L114】
+検索対象に含まれる任意のメタデータ列で絞り込みたい場合は、`--filter "列名=値"` を繰り返し指定すると検索処理の内部で AND 条件として適用されます。例えば `--filter "得意先名=艶栄工業㈱"` を付与すると、該当する得意先名のレコードのみが結果に含まれます。
 
 ### 5. サーバーモード（HTTP API）
 
-`serve` コマンドを使うと、設定ファイルやフラグで指定したデータベースとエンコーダー資産を読み込み、ONNX エンコーダーをメモリ上に保持したまま HTTP サーバーとして待機させられます。【F:main.go†L240-L350】【F:internal/server/server.go†L20-L162】 既定のデータセットやトップK件数、リクエストタイムアウトは `config.json` やフラグで上書きでき、停止シグナル受信時は安全にシャットダウンします。【F:main.go†L260-L350】【F:internal/server/server.go†L86-L105】
+`serve` コマンドを使うと、設定ファイルやフラグで指定したデータベースとエンコーダー資産を読み込み、ONNX エンコーダーをメモリ上に保持したまま HTTP サーバーとして待機させられます。 既定のデータセットやトップK件数、リクエストタイムアウトは `config.json` やフラグで上書きでき、停止シグナル受信時は安全にシャットダウンします。
 
 ```bash
 ./csv-search serve \
@@ -68,14 +68,14 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
 
 サーバー起動後は次のようなエンドポイントが利用できます。
 
-- `GET /search` — クエリ文字列 `q`（または `query`）、`topk`、`table`/`dataset`、`filter=列名=値` を指定して検索します。【F:internal/server/server.go†L166-L188】
-- `POST /search` — JSON で `{"query": "Wi-Fi カフェ", "dataset": "images", "topk": 5, "filters": {"得意先名": "艶栄工業㈱"}}` のように送信できます。【F:internal/server/server.go†L191-L226】
-- `GET /healthz` — ヘルスチェック用の軽量エンドポイントです。【F:internal/server/server.go†L108-L111】
+- `GET /search` — クエリ文字列 `q`（または `query`）、`topk`、`table`/`dataset`、`filter=列名=値` を指定して検索します。
+- `POST /search` — JSON で `{"query": "Wi-Fi カフェ", "dataset": "images", "topk": 5, "filters": {"得意先名": "艶栄工業㈱"}}` のように送信できます。
+- `GET /healthz` — ヘルスチェック用の軽量エンドポイントです。
 
-`filter` パラメータは CLI と同じく `フィールド=値` 形式を複数指定でき、JSON の `filters` マップと合わせて内部で AND 条件として処理されます。【F:internal/server/server.go†L120-L224】【F:internal/server/server.go†L229-L248】 レスポンスは CLI の `search` と同様に検索結果配列の JSON を返すため、既存のパイプラインにそのまま組み込めます。【F:internal/server/server.go†L150-L162】【F:internal/search/vector.go†L25-L115】
+`filter` パラメータは CLI と同じく `フィールド=値` 形式を複数指定でき、JSON の `filters` マップと合わせて内部で AND 条件として処理されます。 レスポンスは CLI の `search` と同様に検索結果配列の JSON を返すため、既存のパイプラインにそのまま組み込めます。
 
 ## データフローと将来構想
-ディレクトリ構成や設定ファイルのアイデア、REST API・Web UI拡張、さらなるランキング強化など、今後の拡張計画も仕様書に整理されています。【F:basePlan.md†L201-L242】【F:basePlan.md†L255-L285】 優先実装順として、差分更新や検索パイプライン強化、フィルタリング、API化、Web UIの追加が計画されています。【F:basePlan.md†L276-L285】
+ディレクトリ構成や設定ファイルのアイデア、REST API・Web UI拡張、さらなるランキング強化など、今後の拡張計画も仕様書に整理されています。 優先実装順として、差分更新や検索パイプライン強化、フィルタリング、API化、Web UIの追加が計画されています。
 
 ## ライセンス
 本リポジトリ内のライセンス情報や再配布条件については、各依存パッケージおよび同梱ファイルのライセンスを参照してください。

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,10 +1,10 @@
 # USAGE
 
-本手順はリポジトリ同梱の`/csv/image.csv`を取り込み、列「実行内容」を意味検索の対象に設定したうえで、必要に応じて列「得意先名」でシステム内フィルタリングを行い、列「受付No」を含む行単位の検索結果を得るまでの流れを説明します。【F:csv/image.csv†L1-L16】【F:main.go†L90-L224】【F:main.go†L353-L414】
+本手順はリポジトリ同梱の`/csv/image.csv`を取り込み、列「実行内容」を意味検索の対象に設定したうえで、必要に応じて列「得意先名」でシステム内フィルタリングを行い、列「受付No」を含む行単位の検索結果を得るまでの流れを説明します。
 
 ## 1. ビルドと前提ファイルの準備
 
-1. Go 1.24 以降と、ONNX Runtime の共有ライブラリ・エンコーダーモデル・トークナイザファイルを利用できる環境を用意します。リポジトリには Windows 向けの `onnixruntime-win/lib/onnxruntime.dll`、推奨モデル `models/bge-m3/model.onnx`・`model.onnx_data`、および `tokenizer.json` が同梱されているため、まずはこれらのパスを利用する想定で進めます。【F:config.json†L2-L24】【F:emb/emb.go†L24-L123】【F:onnxruntimetest.go†L14-L23】
+1. Go 1.24 以降と、ONNX Runtime の共有ライブラリ・エンコーダーモデル・トークナイザファイルを利用できる環境を用意します。リポジトリには Windows 向けの `onnixruntime-win/lib/onnxruntime.dll`、推奨モデル `models/bge-m3/model.onnx`・`model.onnx_data`、および `tokenizer.json` が同梱されているため、まずはこれらのパスを利用する想定で進めます。
 2. リポジトリのルートで次のコマンドを実行し、CLI バイナリ `csv-search` を生成します。
 
    ```bash
@@ -12,25 +12,25 @@
    ```
 
 3. 実行時には以下のファイルを同じディレクトリか任意のパスに配置しておきます。
-   - `csv-search`（ビルド済みバイナリ）【F:main.go†L20-L49】
-   - ONNX Runtime 共有ライブラリ `onnixruntime-win/lib/onnxruntime.dll`（`config.json` の `embedding.ort_lib` で参照）【F:config.json†L5-L9】【F:main.go†L169-L175】【F:main.go†L279-L285】
-   - エンコーダーモデル `models/bge-m3/model.onnx` と `model.onnx_data`【F:config.json†L5-L9】【F:main.go†L177-L183】【F:main.go†L287-L293】
-   - トークナイザ設定 `models/bge-m3/tokenizer.json`【F:config.json†L5-L9】【F:main.go†L185-L191】【F:main.go†L295-L301】
-   - 取り込み対象の CSV ファイル `/csv/image.csv`【F:config.json†L13-L20】【F:csv/image.csv†L1-L16】
+   - `csv-search`（ビルド済みバイナリ）
+   - ONNX Runtime 共有ライブラリ `onnixruntime-win/lib/onnxruntime.dll`（`config.json` の `embedding.ort_lib` で参照）
+   - エンコーダーモデル `models/bge-m3/model.onnx` と `model.onnx_data`
+   - トークナイザ設定 `models/bge-m3/tokenizer.json`
+   - 取り込み対象の CSV ファイル `/csv/image.csv`
 
 ## 2. `config.json` の確認とカスタマイズ
 
-リポジトリ直下に用意した `config.json` は、データベースの保存先や ONNX 関連ファイル、取り込み対象 CSV、デフォルトの検索トップ件数などをまとめて管理します。【F:config.json†L1-L24】 CLI コマンドは起動時にこのファイルを自動的に読み込み（存在しない場合は従来のフラグのみで動作）し、指定がないフラグ値を設定値で補います。【F:main.go†L51-L414】【F:internal/config/config.go†L12-L92】
+リポジトリ直下に用意した `config.json` は、データベースの保存先や ONNX 関連ファイル、取り込み対象 CSV、デフォルトの検索トップ件数などをまとめて管理します。 CLI コマンドは起動時にこのファイルを自動的に読み込み（存在しない場合は従来のフラグのみで動作）し、指定がないフラグ値を設定値で補います。
 
 主要な設定項目は次の通りです。
 
-- `database.path`: SQLite ファイルの出力先。【F:config.json†L2-L4】【F:main.go†L64-L147】【F:main.go†L274-L277】
-- `embedding` ブロック: ONNX Runtime DLL、エンコーダーモデル、トークナイザ、最大トークン長の既定値。【F:config.json†L5-L9】【F:main.go†L169-L207】【F:main.go†L279-L339】
-- `default_dataset`: `ingest` / `search` コマンドが参照する既定データセット名。【F:config.json†L11-L24】【F:main.go†L117-L206】【F:main.go†L260-L307】
-- `datasets.<name>`: CSV パス、ID 列、埋め込み対象列、保持するメタデータ列、バッチサイズなどの取り込み設定。【F:config.json†L13-L20】【F:main.go†L117-L160】
-- `search.default_topk`: 検索の既定件数。【F:config.json†L22-L24】【F:main.go†L303-L339】
+- `database.path`: SQLite ファイルの出力先。
+- `embedding` ブロック: ONNX Runtime DLL、エンコーダーモデル、トークナイザ、最大トークン長の既定値。
+- `default_dataset`: `ingest` / `search` コマンドが参照する既定データセット名。
+- `datasets.<name>`: CSV パス、ID 列、埋め込み対象列、保持するメタデータ列、バッチサイズなどの取り込み設定。
+- `search.default_topk`: 検索の既定件数。
 
-複数のデータセットを扱う場合は `datasets` に別名を追加し、`default_dataset` を切り替えるか、コマンド実行時に `--table` で明示的に指定してください。【F:config.json†L11-L24】【F:main.go†L117-L206】【F:main.go†L353-L414】
+複数のデータセットを扱う場合は `datasets` に別名を追加し、`default_dataset` を切り替えるか、コマンド実行時に `--table` で明示的に指定してください。
 
 ## 3. 初期化と CSV 取り込み
 
@@ -41,9 +41,9 @@
 ./csv-search ingest
 ```
 
-`init` は `database.path` に SQLite ファイルを作成し、スキーマを初期化します。【F:config.json†L2-L4】【F:main.go†L49-L88】【F:internal/database/schema.go†L10-L38】 `ingest` は `datasets.<name>` の設定を基に CSV を読み込み、必要な列から埋め込みを生成してレコード群を保存します。【F:config.json†L13-L20】【F:main.go†L90-L224】【F:internal/ingest/ingest.go†L22-L353】
+`init` は `database.path` に SQLite ファイルを作成し、スキーマを初期化します。 `ingest` は `datasets.<name>` の設定を基に CSV を読み込み、必要な列から埋め込みを生成してレコード群を保存します。
 
-`config.json` 以外を使いたい場合は、`--config ./path/to/custom.json` を各コマンドに付与してください。個別のフラグ (`--db` や `--csv` など) を併用すると、その値が設定ファイルより優先されます。【F:main.go†L53-L224】
+`config.json` 以外を使いたい場合は、`--config ./path/to/custom.json` を各コマンドに付与してください。個別のフラグ (`--db` や `--csv` など) を併用すると、その値が設定ファイルより優先されます。
 
 ## 4. 検索と結果の活用
 
@@ -53,7 +53,7 @@
 ./csv-search search --query "漂白"
 ```
 
-コマンドはクエリをエンコードし、保存済みベクトルとのコサイン類似度でランキングした JSON 配列を標準出力へ返します。結果には `fields` に「受付No」「得意先名」「実行内容」が含まれ、`id` としても「受付No」が保持されます。【F:main.go†L353-L414】【F:internal/search/vector.go†L25-L115】 `--topk`、`--table`、`--db` などを指定すると、設定ファイルの値を上書きできます。【F:main.go†L353-L414】
+コマンドはクエリをエンコードし、保存済みベクトルとのコサイン類似度でランキングした JSON 配列を標準出力へ返します。結果には `fields` に「受付No」「得意先名」「実行内容」が含まれ、`id` としても「受付No」が保持されます。 `--topk`、`--table`、`--db` などを指定すると、設定ファイルの値を上書きできます。
 
 ### メタデータによるシステム内フィルタリング（得意先名）
 
@@ -63,7 +63,7 @@
 ./csv-search search --query "漂白" --filter "得意先名=艶栄工業㈱"
 ```
 
-フィルターは検索処理の内部で適用されるため、`jq` や `grep` など外部ツールに頼らずに目的の得意先名だけを抽出できます。複数条件を AND で組み合わせたい場合は `--filter` を繰り返し指定してください。【F:csv/image.csv†L1-L16】【F:internal/search/vector.go†L16-L114】【F:main.go†L199-L413】
+フィルターは検索処理の内部で適用されるため、`jq` や `grep` など外部ツールに頼らずに目的の得意先名だけを抽出できます。複数条件を AND で組み合わせたい場合は `--filter` を繰り返し指定してください。
 
 ### 受付No を含む行出力の確認
 
@@ -73,4 +73,4 @@
 ./csv-search search --query "漂白" | jq -r ".[] | \"受付No: \(.fields[\"受付No\"]) / 得意先名: \(.fields[\"得意先名\"]) / 実行内容: \(.fields[\"実行内容\"])\""
 ```
 
-これにより、「受付No」「得意先名」「実行内容」を同一行で確認しながら検索結果を活用できます。【F:config.json†L13-L20】【F:csv/image.csv†L1-L16】【F:internal/search/vector.go†L25-L115】
+これにより、「受付No」「得意先名」「実行内容」を同一行で確認しながら検索結果を活用できます。

--- a/csv-search.md
+++ b/csv-search.md
@@ -4,43 +4,43 @@
 csv-search は CSV データを取り込み、ONNX Runtime を用いて文書ベクトルを生成し、SQLite に保存された埋め込みを使ってセマンティック検索を提供するアプリケーションです。CLI ツールとして単体で利用できるほか、`pkg/csvsearch` パッケージを経由して別の Go アプリケーションへ統合できます。
 
 ## 主な機能
-- **データベース初期化**: SQLite スキーマの作成・更新。CLI の `init` サブコマンドおよび `Service.InitDatabase` で実施。【F:pkg/csvsearch/init.go†L7-L26】【F:main.go†L43-L73】
-- **CSV 取り込み**: CSV 行を読み込み、ONNX エンコーダーでテキストをベクトル化してデータベースへアップサート。`ingest` サブコマンドまたは `Service.Ingest` で利用可能。【F:pkg/csvsearch/ingest.go†L16-L121】【F:main.go†L75-L137】
-- **セマンティック検索**: クエリをベクトル化してコサイン類似度でランキング。`search` サブコマンドおよび `Service.Search` が提供し、結果は JSON 配列として取得できます。【F:pkg/csvsearch/search.go†L8-L70】【F:main.go†L139-L189】
-- **HTTP API サーバー**: REST エンドポイント (`/search`, `/healthz`) を提供。CLI の `serve` サブコマンドか `Service.StartServer` / `Service.NewAPIServer` で起動・統合可能。`internal/server.Server.Handler` により既存の HTTP サーバーへマウントすることもできます。【F:pkg/csvsearch/server.go†L7-L101】【F:internal/server/server.go†L70-L104】【F:main.go†L191-L240】
+- **データベース初期化**: SQLite スキーマの作成・更新。CLI の `init` サブコマンドおよび `Service.InitDatabase` で実施。
+- **CSV 取り込み**: CSV 行を読み込み、ONNX エンコーダーでテキストをベクトル化してデータベースへアップサート。`ingest` サブコマンドまたは `Service.Ingest` で利用可能。
+- **セマンティック検索**: クエリをベクトル化してコサイン類似度でランキング。`search` サブコマンドおよび `Service.Search` が提供し、結果は JSON 配列として取得できます。
+- **HTTP API サーバー**: REST エンドポイント (`/search`, `/healthz`) を提供。CLI の `serve` サブコマンドか `Service.StartServer` / `Service.NewAPIServer` で起動・統合可能。`internal/server.Server.Handler` により既存の HTTP サーバーへマウントすることもできます。
 
 ## 必要なもの
-- **SQLite ドライバー**: `modernc.org/sqlite` を使用しており、CGO なしでビルド可能です。【F:pkg/csvsearch/service.go†L9-L11】【F:go.mod†L6-L13】
-- **ONNX Runtime DLL/共有ライブラリ**: `emb.Encoder` の `OrtDLL` へパスを指定する必要があります。Windows 向け `.dll` などを想定しています。【F:emb/emb.go†L1-L105】【F:pkg/csvsearch/service.go†L88-L116】
-- **エンコーダーモデル/トークナイザー**: ONNX モデル (`model.onnx`) と `tokenizer.json` を `EncoderConfig` または設定ファイルから指定。【F:pkg/csvsearch/service.go†L88-L116】【F:internal/config/config.go†L15-L52】
-- **設定ファイル (任意)**: `config.json` 形式でデータベースパス、エンコーディング資産、デフォルトデータセット、検索設定を定義できます。【F:internal/config/config.go†L11-L66】
-- **CSV データ**: 取り込み対象。デフォルトでは `id` 列とテキスト列（`text-cols` or `meta-cols`）が必要です。【F:pkg/csvsearch/ingest.go†L48-L103】
+- **SQLite ドライバー**: `modernc.org/sqlite` を使用しており、CGO なしでビルド可能です。
+- **ONNX Runtime DLL/共有ライブラリ**: `emb.Encoder` の `OrtDLL` へパスを指定する必要があります。Windows 向け `.dll` などを想定しています。
+- **エンコーダーモデル/トークナイザー**: ONNX モデル (`model.onnx`) と `tokenizer.json` を `EncoderConfig` または設定ファイルから指定。
+- **設定ファイル (任意)**: `config.json` 形式でデータベースパス、エンコーディング資産、デフォルトデータセット、検索設定を定義できます。
+- **CSV データ**: 取り込み対象。デフォルトでは `id` 列とテキスト列（`text-cols` or `meta-cols`）が必要です。
 
 ## 入出力
 - **取り込み (`Ingest`) 入力**
-  - `IngestOptions` で CSV パス、ID 列、テキスト列、メタデータ列、緯度経度列などを指定。省略時は設定ファイルのデータセット定義が自動適用されます。【F:pkg/csvsearch/ingest.go†L16-L103】
-  - 出力として `IngestSummary` を返し、使用されたパラメータを参照できます。【F:pkg/csvsearch/ingest.go†L18-L27】【F:pkg/csvsearch/ingest.go†L105-L121】
+  - `IngestOptions` で CSV パス、ID 列、テキスト列、メタデータ列、緯度経度列などを指定。省略時は設定ファイルのデータセット定義が自動適用されます。
+  - 出力として `IngestSummary` を返し、使用されたパラメータを参照できます。
 - **検索 (`Search`) 入力/出力**
-  - `SearchOptions` はクエリ文字列、対象データセット、TopK、フィルター（`Filter` 構造体）を受け取ります。【F:pkg/csvsearch/search.go†L24-L37】
-  - 戻り値は `Result` のスライスで、ID・スコア・メタデータ・位置情報を含む JSON 互換構造です。【F:pkg/csvsearch/search.go†L10-L22】【F:pkg/csvsearch/search.go†L39-L68】
+  - `SearchOptions` はクエリ文字列、対象データセット、TopK、フィルター（`Filter` 構造体）を受け取ります。
+  - 戻り値は `Result` のスライスで、ID・スコア・メタデータ・位置情報を含む JSON 互換構造です。
 - **HTTP API**
-  - `/search`: GET/POST 共通。`q`/`query`、`dataset`/`table`、`topk`、`filter=field=value` をサポート。【F:internal/server/server.go†L96-L165】
-  - `/healthz`: サーバーヘルスチェック用。常に `200 OK` を返します。【F:internal/server/server.go†L88-L94】
+  - `/search`: GET/POST 共通。`q`/`query`、`dataset`/`table`、`topk`、`filter=field=value` をサポート。
+  - `/healthz`: サーバーヘルスチェック用。常に `200 OK` を返します。
 
 ## Go 統合ポイント
-- **Service 構築**: `NewService(ServiceOptions)` で設定・DB・エンコーダー（遅延初期化）を一括管理。外部から提供された DB/エンコーダーを再利用できます。【F:pkg/csvsearch/service.go†L33-L117】
-- **データベースパス取得**: `Service.DatabasePath()` で実際に使用している SQLite ファイルのパスを取得可能（外部接続時は空文字）。【F:pkg/csvsearch/service.go†L61-L68】
-- **HTTP 統合**: `APIServer.Handler()` を既存ルーターに登録、または `APIServer.Serve(ctx)` で単独起動。【F:pkg/csvsearch/server.go†L23-L55】
-- **Graceful Shutdown**: `StartServer` は `context.Context` を介して OS シグナルなどに対応し、自動でデータセットを取り込みます（設定に CSV パスがある場合）。【F:pkg/csvsearch/server.go†L57-L101】
+- **Service 構築**: `NewService(ServiceOptions)` で設定・DB・エンコーダー（遅延初期化）を一括管理。外部から提供された DB/エンコーダーを再利用できます。
+- **データベースパス取得**: `Service.DatabasePath()` で実際に使用している SQLite ファイルのパスを取得可能（外部接続時は空文字）。
+- **HTTP 統合**: `APIServer.Handler()` を既存ルーターに登録、または `APIServer.Serve(ctx)` で単独起動。
+- **Graceful Shutdown**: `StartServer` は `context.Context` を介して OS シグナルなどに対応し、自動でデータセットを取り込みます（設定に CSV パスがある場合）。
 
 ## CLI サブコマンド概要
 | コマンド | 主なオプション | 概要 |
 |----------|----------------|------|
-| `init`   | `--config`, `--db` | SQLite スキーマ初期化。デフォルトは `config.json` と `data/app.db`。【F:main.go†L43-L73】 |
-| `ingest` | `--csv`, `--table`, `--text-cols`, `--meta-cols`, `--lat-col`, `--lng-col`, `--ort-lib`, `--model`, `--tokenizer`, `--max-seq-len` | CSV を読み込みベクトル化し保存。終了後に取り込み概要を出力。【F:main.go†L75-L137】 |
-| `search` | `--query`, `--table`, `--topk`, `--filter`, エンコーダー関連オプション | クエリを検索し、JSON 形式で結果を標準出力。【F:main.go†L139-L189】 |
-| `serve`  | `--addr`, `--table`, `--topk`, `--request-timeout`, `--shutdown-timeout`, エンコーダー関連オプション | HTTP API サーバーを起動。Ctrl+C などでグレースフル終了。【F:main.go†L191-L240】 |
+| `init`   | `--config`, `--db` | SQLite スキーマ初期化。デフォルトは `config.json` と `data/app.db`。 |
+| `ingest` | `--csv`, `--table`, `--text-cols`, `--meta-cols`, `--lat-col`, `--lng-col`, `--ort-lib`, `--model`, `--tokenizer`, `--max-seq-len` | CSV を読み込みベクトル化し保存。終了後に取り込み概要を出力。 |
+| `search` | `--query`, `--table`, `--topk`, `--filter`, エンコーダー関連オプション | クエリを検索し、JSON 形式で結果を標準出力。 |
+| `serve`  | `--addr`, `--table`, `--topk`, `--request-timeout`, `--shutdown-timeout`, エンコーダー関連オプション | HTTP API サーバーを起動。Ctrl+C などでグレースフル終了。 |
 
 ## ビルドに関する注意
-- Windows 向け `.exe` ビルドを想定する場合、`GOOS=windows` とし、`EncoderConfig` の `OrtLibrary` に ONNX Runtime の DLL を指定してください。`modernc.org/sqlite` を採用しているため、CGO 無効のままクロスビルドが可能です。【F:pkg/csvsearch/service.go†L9-L11】【F:pkg/csvsearch/service.go†L88-L116】
-- ONNX ランタイム DLL、モデルファイル、トークナイザーをアプリと同じディレクトリに配置するか、設定ファイルで絶対パス/相対パスを指定してください。【F:internal/config/config.go†L40-L52】【F:pkg/csvsearch/service.go†L88-L116】
+- Windows 向け `.exe` ビルドを想定する場合、`GOOS=windows` とし、`EncoderConfig` の `OrtLibrary` に ONNX Runtime の DLL を指定してください。`modernc.org/sqlite` を採用しているため、CGO 無効のままクロスビルドが可能です。
+- ONNX ランタイム DLL、モデルファイル、トークナイザーをアプリと同じディレクトリに配置するか、設定ファイルで絶対パス/相対パスを指定してください。


### PR DESCRIPTION
## Summary
- remove the fullwidth citation brackets from csv-search.md, README.md, and USAGE.md to improve readability

## Testing
- go test ./... *(fails: missing go.sum entry for modernc.org/sqlite because module downloads are forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cde103c6e08323981567c313da9f85