### PR TITLE
Support /query alias and tolerant search payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Go 1.24以降とONNX Runtime（共有ライブラリ）、推奨エンコーダ�
 
 - `GET /search` — クエリ文字列 `q`（または `query`）、`topk`、`table`/`dataset`、`filter=列名=値` を指定して検索します。
 - `POST /search` — JSON で `{"query": "Wi-Fi カフェ", "dataset": "images", "topk": 5, "filters": {"得意先名": "艶栄工業㈱"}}` のように送信できます。
+- `POST /query` — `/search` と同じ検索を行うエイリアスです。JSON では `max_results` を `topk` の代わりに利用でき、`summary_only` フラグを指定してもエラーになりません。
 - `GET /healthz` — ヘルスチェック用の軽量エンドポイントです。
 
 `filter` パラメータは CLI と同じく `フィールド=値` 形式を複数指定でき、JSON の `filters` マップと合わせて内部で AND 条件として処理されます。 レスポンスは CLI の `search` と同様に検索結果配列の JSON を返すため、既存のパイプラインにそのまま組み込めます。

--- a/csv-search.md
+++ b/csv-search.md
@@ -102,6 +102,7 @@
 ## HTTP API Contract
 - **`GET /search`**: Query parameters `q`/`query`, `dataset`/`table`, `topk`, and repeated `filter=field=value`.
 - **`POST /search`**: JSON body `{"query": "text", "dataset": "name", "topk": 5, "filters": {"列": "値"}}`. Arrays under `filter` are also accepted.
+- **`POST /query`**: Alias of `/search` that also accepts `max_results` instead of `topk` and tolerates an optional `summary_only` flag for compatibility with external tools.
 - **`GET /healthz`**: Returns `200 OK` with body `ok`.
 - Responses mirror CLI search results. Timeout defaults to 30 s; exceeding it returns HTTP 504.
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDecodeSearchRequestPostMaxResults(t *testing.T) {
+	s := &Server{}
+	body := `{"query":"テスト","dataset":"textile_jobs","max_results":2,"summary_only":true,"filters":{"得意先名":"艶栄工業㈱"}}`
+	req := httptest.NewRequest(http.MethodPost, "/query", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	decoded, err := s.decodeSearchRequest(req)
+	if err != nil {
+		t.Fatalf("decodeSearchRequest returned error: %v", err)
+	}
+	if decoded.Query != "テスト" {
+		t.Fatalf("unexpected query: %q", decoded.Query)
+	}
+	if decoded.Dataset != "textile_jobs" {
+		t.Fatalf("unexpected dataset: %q", decoded.Dataset)
+	}
+	if decoded.TopK != 2 {
+		t.Fatalf("expected TopK=2, got %d", decoded.TopK)
+	}
+	if !decoded.SummaryOnly {
+		t.Fatalf("expected SummaryOnly=true")
+	}
+	if len(decoded.Filters) != 1 {
+		t.Fatalf("expected 1 filter, got %d", len(decoded.Filters))
+	}
+	filter := decoded.Filters[0]
+	if filter.Field != "得意先名" || filter.Value != "艶栄工業㈱" {
+		t.Fatalf("unexpected filter parsed: %+v", filter)
+	}
+}
+
+func TestDecodeSearchRequestGetMaxResults(t *testing.T) {
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/query?query=hello&max_results=3&summary_only=true", nil)
+
+	decoded, err := s.decodeSearchRequest(req)
+	if err != nil {
+		t.Fatalf("decodeSearchRequest returned error: %v", err)
+	}
+	if decoded.Query != "hello" {
+		t.Fatalf("unexpected query: %q", decoded.Query)
+	}
+	if decoded.TopK != 3 {
+		t.Fatalf("expected TopK=3, got %d", decoded.TopK)
+	}
+	if !decoded.SummaryOnly {
+		t.Fatalf("expected SummaryOnly=true")
+	}
+}


### PR DESCRIPTION
## Summary
- add an HTTP alias for `/query` so the API accepts clients targeting that route
- accept `max_results`, `summary_only`, and `table` aliases when decoding search requests while leaving existing behaviour intact
- document the new alias and add unit tests covering the request decoding changes

## Testing
- go test ./internal/server


------
https://chatgpt.com/codex/tasks/task_e_68cf480781fc8323a10c49cbbc093ce7