### PR TITLE
Auto initialize database when missing

### DIFF
--- a/pkg/csvsearch/ingest.go
+++ b/pkg/csvsearch/ingest.go
@@ -78,7 +78,7 @@ func (s *Service) Ingest(ctx context.Context, opts IngestOptions) (IngestSummary
 	latitude := firstNonEmpty(strings.TrimSpace(opts.LatitudeColumn), dataset.LatColumn)
 	longitude := firstNonEmpty(strings.TrimSpace(opts.LongitudeColumn), dataset.LngColumn)
 
-	if err := s.InitDatabase(ctx, InitDatabaseOptions{}); err != nil {
+	if err := s.ensureDatabase(ctx); err != nil {
 		return IngestSummary{}, err
 	}
 

--- a/pkg/csvsearch/init.go
+++ b/pkg/csvsearch/init.go
@@ -31,5 +31,19 @@ func (s *Service) InitDatabase(ctx context.Context, opts InitDatabaseOptions) er
 	initCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return database.Init(initCtx, s.db)
+	if err := database.Init(initCtx, s.db); err != nil {
+		return err
+	}
+	s.setDatabaseReady(true)
+	return nil
+}
+
+func (s *Service) ensureDatabase(ctx context.Context) error {
+	if s.databaseReady() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.InitDatabase(ctx, InitDatabaseOptions{})
 }

--- a/pkg/csvsearch/search.go
+++ b/pkg/csvsearch/search.go
@@ -48,6 +48,10 @@ func (s *Service) Search(ctx context.Context, opts SearchOptions) ([]Result, err
 		return nil, fmt.Errorf("query is required")
 	}
 
+	if err := s.ensureDatabase(ctx); err != nil {
+		return nil, err
+	}
+
 	datasetName, dataset, _ := resolveDataset(s.cfg, opts.Dataset)
 	table := resolveTable(datasetName, dataset, opts.Table)
 	limit := firstPositive(opts.TopK, cfgSearchTopK(s.cfg), 10)

--- a/pkg/csvsearch/server.go
+++ b/pkg/csvsearch/server.go
@@ -52,6 +52,10 @@ func (s *Service) NewAPIServer(opts ServeOptions) (*APIServer, error) {
 		return nil, fmt.Errorf("database handle is nil")
 	}
 
+	if err := s.ensureDatabase(context.Background()); err != nil {
+		return nil, err
+	}
+
 	datasetName, datasetCfg, _ := resolveDataset(s.cfg, opts.Dataset)
 	table := resolveTable(datasetName, datasetCfg, opts.Table)
 	defaultTopK := firstPositive(opts.TopK, cfgSearchTopK(s.cfg), 10)
@@ -94,7 +98,7 @@ func (s *Service) StartServer(ctx context.Context, opts ServeOptions) error {
 		return fmt.Errorf("context must not be nil")
 	}
 
-	if err := s.InitDatabase(ctx, InitDatabaseOptions{}); err != nil {
+	if err := s.ensureDatabase(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- track database initialization state on the Service so the schema is only prepared when needed
- add an internal ensureDatabase helper that marks the database ready and falls back to a background context when necessary
- call the helper from ingestion, search, and server setup so DB files and schemas are created automatically on first use

## Testing
- go test ./... *(fails: unable to download modernc.org/sqlite dependencies in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa2529d2883239e98735ead2bfd40